### PR TITLE
Refactor and prepare for Python API

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,8 +1,7 @@
-use std::io::Write;
-
 use dicom::dictionary_std::tags;
 use dicom::object::{FileDicomObject, InMemDicomObject};
 use dicom::pixeldata::PhotometricInterpretation;
+use image::{DynamicImage, ImageBuffer, Luma, Rgb};
 use snafu::{ResultExt, Snafu};
 use tiff::encoder::colortype::{Gray16, RGB8};
 
@@ -79,4 +78,8 @@ impl TryFrom<&FileDicomObject<InMemDicomObject>> for DicomColorType {
 
         DicomColorType::try_new(bits_allocated, photometric_interpretation)
     }
+}
+
+trait TiffColorMap {
+    fn as_fn(&self) -> &'static str;
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,7 +1,6 @@
 use dicom::dictionary_std::tags;
 use dicom::object::{FileDicomObject, InMemDicomObject};
 use dicom::pixeldata::PhotometricInterpretation;
-use image::{DynamicImage, ImageBuffer, Luma, Rgb};
 use snafu::{ResultExt, Snafu};
 use tiff::encoder::colortype::{Gray16, RGB8};
 
@@ -78,8 +77,4 @@ impl TryFrom<&FileDicomObject<InMemDicomObject>> for DicomColorType {
 
         DicomColorType::try_new(bits_allocated, photometric_interpretation)
     }
-}
-
-trait TiffColorMap {
-    fn as_fn(&self) -> &'static str;
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,82 @@
+use std::io::Write;
+
+use dicom::dictionary_std::tags;
+use dicom::object::{FileDicomObject, InMemDicomObject};
+use dicom::pixeldata::PhotometricInterpretation;
+use snafu::{ResultExt, Snafu};
+use tiff::encoder::colortype::{Gray16, RGB8};
+
+#[derive(Debug, Snafu)]
+pub enum ColorError {
+    MissingProperty {
+        name: &'static str,
+    },
+    CastPropertyValue {
+        name: &'static str,
+        #[snafu(source(from(dicom::core::value::CastValueError, Box::new)))]
+        source: Box<dicom::core::value::CastValueError>,
+    },
+    UnsupportedPhotometricInterpretation {
+        bits_allocated: u16,
+        photometric_interpretation: PhotometricInterpretation,
+    },
+}
+
+/// The color types we expect to encounter in DICOM files and support processing of
+pub enum DicomColorType {
+    Gray16(Gray16),
+    RGB8(RGB8),
+}
+
+impl DicomColorType {
+    /// Infer color type from BitsAllocated and PhotometricInterpretation
+    pub fn try_new(
+        bits_allocated: u16,
+        photometric_interpretation: PhotometricInterpretation,
+    ) -> Result<Self, ColorError> {
+        match (bits_allocated, photometric_interpretation) {
+            (16, PhotometricInterpretation::Monochrome1)
+            | (16, PhotometricInterpretation::Monochrome2) => Ok(DicomColorType::Gray16(Gray16)),
+            (8, PhotometricInterpretation::Rgb) => Ok(DicomColorType::RGB8(RGB8)),
+            (bits_allocated, photometric_interpretation) => {
+                Err(ColorError::UnsupportedPhotometricInterpretation {
+                    bits_allocated,
+                    photometric_interpretation,
+                })
+            }
+        }
+    }
+}
+
+impl TryFrom<&FileDicomObject<InMemDicomObject>> for DicomColorType {
+    type Error = ColorError;
+
+    /// Read the BitsAllocated and PhotometricInterpretation tags from the DICOM file
+    /// and infer the appropriate color type.
+    fn try_from(file: &FileDicomObject<InMemDicomObject>) -> Result<Self, Self::Error> {
+        let bits_allocated = file
+            .get(tags::BITS_ALLOCATED)
+            .ok_or(ColorError::MissingProperty {
+                name: "Bits Allocated",
+            })?
+            .value()
+            .uint16()
+            .context(CastPropertyValueSnafu {
+                name: "Bits Allocated",
+            })?;
+        let photometric_interpretation = file
+            .get(tags::PHOTOMETRIC_INTERPRETATION)
+            .ok_or(ColorError::MissingProperty {
+                name: "Photometric Interpretation",
+            })?
+            .value()
+            .string()
+            .context(CastPropertyValueSnafu {
+                name: "Photometric Interpretation",
+            })?;
+        let photometric_interpretation =
+            PhotometricInterpretation::from(photometric_interpretation.trim());
+
+        DicomColorType::try_new(bits_allocated, photometric_interpretation)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod color;
 pub mod metadata;
 pub mod preprocess;
+pub mod save;
 pub mod transform;
 
 pub use color::*;
 pub use metadata::*;
 pub use preprocess::*;
+pub use save::*;
 pub use transform::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod color;
 pub mod metadata;
 pub mod preprocess;
 pub mod transform;
 
+pub use color::*;
 pub use metadata::*;
 pub use preprocess::*;
 pub use transform::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ fn process(
         std::fs::create_dir_all(parent).context(CreateDirSnafu { path: parent })?;
         filepath
     } else {
-        dest.clone()
+        dest.to_path_buf()
     };
 
     tracing::info!("Processing {} -> {}", source.display(), dest.display());
@@ -349,7 +349,7 @@ fn process(
 
     let saver = TiffSaver::new(compressor.into(), color_type);
     saver
-        .save_all(images, metadata, &dest)
+        .save_all(images, metadata, dest)
         .context(SaveToTiffSnafu)?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 
 use dicom_preprocessing::color::ColorError;
 use dicom_preprocessing::preprocess::PreprocessError;
-use dicom_preprocessing::save::{SaveError, SaveToTiff, TiffSaver};
+use dicom_preprocessing::save::{SaveError, TiffSaver};
 use dicom_preprocessing::transform::volume::DisplayVolumeHandler;
 
 #[derive(Debug, Snafu)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,8 +348,10 @@ fn process(
     let color_type = DicomColorType::try_from(&file).context(ColorTypeSnafu)?;
 
     let saver = TiffSaver::new(compressor.into(), color_type);
-    saver
-        .save_all(images, metadata, dest)
+    let mut encoder = saver.open_tiff(dest).unwrap();
+    images
+        .into_iter()
+        .try_for_each(|image| saver.save(&mut encoder, &image, &metadata))
         .context(SaveToTiffSnafu)?;
 
     Ok(())

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -8,6 +8,9 @@ use tiff::TiffError;
 pub mod resolution;
 pub use resolution::*;
 
+pub mod preprocessing;
+pub use preprocessing::*;
+
 pub trait WriteTags {
     /// Write tags describing the transform to a TIFF encoder.
     fn write_tags<W, C, K, D>(&self, tiff: &mut ImageEncoder<W, C, K, D>) -> Result<(), TiffError>

--- a/src/metadata/preprocessing.rs
+++ b/src/metadata/preprocessing.rs
@@ -1,4 +1,5 @@
-use std::io::{Seek, Write};
+use std::io::{Read, Seek, Write};
+use tiff::decoder::Decoder;
 use tiff::encoder::colortype::ColorType;
 use tiff::encoder::compression::Compression;
 use tiff::encoder::{ImageEncoder, TiffKind};
@@ -11,6 +12,7 @@ use crate::transform::{Crop, Padding, Resize};
 const VERSION: &str = concat!("dicom-preprocessing==", env!("CARGO_PKG_VERSION"), "\0");
 
 /// Tracks all of the preprocessing metadata and augmentations
+#[derive(Debug, PartialEq)]
 pub struct PreprocessingMetadata {
     pub crop: Option<Crop>,
     pub resize: Option<Resize>,
@@ -19,6 +21,7 @@ pub struct PreprocessingMetadata {
 }
 
 impl WriteTags for PreprocessingMetadata {
+    /// Writes TIFF tags for the respective transforms, along with version and resolution metadata
     fn write_tags<W, C, K, D>(&self, tiff: &mut ImageEncoder<W, C, K, D>) -> Result<(), TiffError>
     where
         W: Write + Seek,
@@ -48,3 +51,65 @@ impl WriteTags for PreprocessingMetadata {
     }
 }
 
+impl<T> From<&mut Decoder<T>> for PreprocessingMetadata
+where
+    T: Read + Seek,
+{
+    /// Read the preprocessing metadata from the TIFF file
+    fn from(decoder: &mut Decoder<T>) -> Self {
+        // NOTE: We don't distinguish between an unexpected error and an expected missing/malformed tag.
+        // The TIFF could be using these tags for another purpose, e.g. if it was created by a different software.
+        let crop = Crop::try_from(&mut *decoder).ok();
+        let resize = Resize::try_from(&mut *decoder).ok();
+        let padding = Padding::try_from(&mut *decoder).ok();
+        let resolution = Resolution::try_from(&mut *decoder).ok();
+        Self {
+            crop,
+            resize,
+            padding,
+            resolution,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::imageops::FilterType;
+
+    use rstest::rstest;
+    use std::fs::File;
+    use tempfile::tempdir;
+    use tiff::encoder::TiffEncoder;
+
+    #[rstest]
+    #[case(
+        PreprocessingMetadata {
+            crop: Some(Crop { left: 0, top: 0, width: 1, height: 1 }),
+            resize: Some(Resize { scale_x: 2.0, scale_y: 2.0, filter: FilterType::Nearest }),
+            padding: Some(Padding { left: 0, top: 0, right: 1, bottom: 1 }),
+            resolution: Some(Resolution { pixels_per_mm_x: 1.0, pixels_per_mm_y: 1.0 }),
+        }
+    )]
+    fn test_write_tags(#[case] metadata: PreprocessingMetadata) {
+        // Prepare the TIFF
+        let temp_dir = tempdir().unwrap();
+        let temp_file_path = temp_dir.path().join("temp.tif");
+        let mut tiff = TiffEncoder::new(File::create(temp_file_path.clone()).unwrap()).unwrap();
+        let mut img = tiff
+            .new_image::<tiff::encoder::colortype::Gray16>(1, 1)
+            .unwrap();
+
+        // Write the tags
+        metadata.write_tags(&mut img).unwrap();
+
+        // Write some dummy image data
+        let data: Vec<u16> = vec![0; 2];
+        img.write_data(data.as_slice()).unwrap();
+
+        // Read the TIFF back
+        let mut tiff = Decoder::new(File::open(temp_file_path).unwrap()).unwrap();
+        let actual = PreprocessingMetadata::from(&mut tiff);
+        assert_eq!(metadata, actual);
+    }
+}

--- a/src/metadata/preprocessing.rs
+++ b/src/metadata/preprocessing.rs
@@ -1,0 +1,50 @@
+use std::io::{Seek, Write};
+use tiff::encoder::colortype::ColorType;
+use tiff::encoder::compression::Compression;
+use tiff::encoder::{ImageEncoder, TiffKind};
+use tiff::tags::Tag;
+use tiff::TiffError;
+
+use crate::metadata::{Resolution, WriteTags};
+use crate::transform::{Crop, Padding, Resize};
+
+const VERSION: &str = concat!("dicom-preprocessing==", env!("CARGO_PKG_VERSION"), "\0");
+
+/// Tracks all of the preprocessing metadata and augmentations
+pub struct PreprocessingMetadata {
+    pub crop: Option<Crop>,
+    pub resize: Option<Resize>,
+    pub padding: Option<Padding>,
+    pub resolution: Option<Resolution>,
+}
+
+impl WriteTags for PreprocessingMetadata {
+    fn write_tags<W, C, K, D>(&self, tiff: &mut ImageEncoder<W, C, K, D>) -> Result<(), TiffError>
+    where
+        W: Write + Seek,
+        C: ColorType,
+        K: TiffKind,
+        D: Compression,
+    {
+        // Write the resolution tag
+        if let Some(resolution) = &self.resolution {
+            resolution.write_tags(tiff)?;
+        }
+        // Write metadata software tag
+        tiff.encoder()
+            .write_tag(Tag::Software, VERSION.as_bytes())?;
+
+        // Write transform related tags
+        if let Some(crop_config) = &self.crop {
+            crop_config.write_tags(tiff)?;
+        }
+        if let Some(resize_config) = &self.resize {
+            resize_config.write_tags(tiff)?;
+        }
+        if let Some(padding_config) = &self.padding {
+            padding_config.write_tags(tiff)?;
+        }
+        Ok(())
+    }
+}
+

--- a/src/metadata/resolution.rs
+++ b/src/metadata/resolution.rs
@@ -12,8 +12,8 @@ use snafu::{ResultExt, Snafu};
 
 use crate::metadata::WriteTags;
 
-const CM_PER_MM: f32 = 10.0;
-const IN_PER_MM: f32 = 25.4;
+const MM_PER_CM: f32 = 10.0;
+const MM_PER_IN: f32 = 25.4;
 
 #[derive(Debug, Snafu)]
 pub enum ResolutionError {
@@ -92,8 +92,8 @@ where
 
         // Convert to pixels per mm
         let (x_resolution, y_resolution) = match unit {
-            ResolutionUnit::Centimeter => (x_resolution / CM_PER_MM, y_resolution / CM_PER_MM),
-            ResolutionUnit::Inch => (x_resolution / IN_PER_MM, y_resolution / IN_PER_MM),
+            ResolutionUnit::Centimeter => (x_resolution / MM_PER_CM, y_resolution / MM_PER_CM),
+            ResolutionUnit::Inch => (x_resolution / MM_PER_IN, y_resolution / MM_PER_IN),
             _ => (x_resolution, y_resolution),
         };
 
@@ -122,11 +122,11 @@ impl WriteTags for Resolution {
         D: Compression,
     {
         tiff.x_resolution(Rational {
-            n: (self.pixels_per_mm_x * CM_PER_MM) as u32,
+            n: (self.pixels_per_mm_x * MM_PER_CM) as u32,
             d: 1,
         });
         tiff.y_resolution(Rational {
-            n: (self.pixels_per_mm_y * CM_PER_MM) as u32,
+            n: (self.pixels_per_mm_y * MM_PER_CM) as u32,
             d: 1,
         });
         tiff.resolution_unit(tiff::tags::ResolutionUnit::Centimeter);

--- a/src/metadata/resolution.rs
+++ b/src/metadata/resolution.rs
@@ -140,6 +140,15 @@ impl From<Resolution> for (f32, f32) {
     }
 }
 
+impl From<(f32, f32)> for Resolution {
+    fn from((pixels_per_mm_x, pixels_per_mm_y): (f32, f32)) -> Self {
+        Resolution {
+            pixels_per_mm_x,
+            pixels_per_mm_y,
+        }
+    }
+}
+
 impl TryFrom<&FileDicomObject<InMemDicomObject>> for Resolution {
     type Error = ResolutionError;
 
@@ -176,10 +185,7 @@ impl TryFrom<&FileDicomObject<InMemDicomObject>> for Resolution {
             .context(ParsePixelSpacingSnafu)?;
 
         // Convert to pixels per mm
-        Ok(Resolution {
-            pixels_per_mm_x: 1.0 / pixel_spacing_mm_x,
-            pixels_per_mm_y: 1.0 / pixel_spacing_mm_y,
-        })
+        Ok((1.0 / pixel_spacing_mm_x, 1.0 / pixel_spacing_mm_y).into())
     }
 }
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -1,22 +1,9 @@
 use image::DynamicImage;
-use image::GenericImageView;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-use tiff::encoder::colortype::ColorType;
-use tiff::encoder::compression::{Compression, Compressor, Packbits};
-use tiff::encoder::TiffEncoder;
-use tiff::TiffError;
 
-use dicom::dictionary_std::tags;
-use dicom::object::{FileDicomObject, InMemDicomObject, ReadError};
-use dicom::pixeldata::PhotometricInterpretation;
+use dicom::object::{FileDicomObject, InMemDicomObject};
 use image::imageops::FilterType;
 use snafu::{ResultExt, Snafu};
-use tiff::encoder::colortype::{Gray16, RGB8};
-use tiff::encoder::compression::{Lzw, Uncompressed};
 
-use crate::color::{ColorError, DicomColorType};
 use crate::metadata::{PreprocessingMetadata, Resolution};
 use crate::transform::volume::VolumeError;
 use crate::transform::{

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -164,6 +164,39 @@ mod tests {
             volume_handler: VolumeHandler::CentralSlice(CentralSlice),
         }
     )]
+    #[case(
+        "pydicom/JPEG2000_UNC.dcm",
+        Preprocessor {
+            crop: false,
+            size: None,
+            filter: FilterType::Nearest,
+            padding_direction: PaddingDirection::default(),
+            crop_max: false,
+            volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+        }
+    )]
+    #[case(
+        "pydicom/US1_J2KI.dcm",
+        Preprocessor {
+            crop: false,
+            size: None,
+            filter: FilterType::Nearest,
+            padding_direction: PaddingDirection::default(),
+            crop_max: false,
+            volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+        }
+    )]
+    #[case(
+        "pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm",
+        Preprocessor {
+            crop: false,
+            size: None,
+            filter: FilterType::Nearest,
+            padding_direction: PaddingDirection::default(),
+            crop_max: false,
+            volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+        }
+    )]
     fn test_preprocess(#[case] dicom_file_path: &str, #[case] config: Preprocessor) {
         let dicom_file = open_file(&dicom_test_files::path(dicom_file_path).unwrap()).unwrap();
 

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,0 +1,261 @@
+use image::DynamicImage;
+use image::GenericImageView;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use tiff::encoder::colortype::ColorType;
+use tiff::encoder::compression::{Compression, Compressor, Deflate, Packbits};
+use tiff::encoder::TiffEncoder;
+use tiff::TiffError;
+
+use dicom::dictionary_std::tags;
+use dicom::object::{FileDicomObject, InMemDicomObject, ReadError};
+use dicom::pixeldata::PhotometricInterpretation;
+use image::imageops::FilterType;
+use snafu::{ResultExt, Snafu};
+use tiff::encoder::colortype::{Gray16, RGB8};
+use tiff::encoder::compression::{Lzw, Uncompressed};
+
+use crate::color::{ColorError, DicomColorType};
+use crate::metadata::{PreprocessingMetadata, Resolution, WriteTags};
+use crate::transform::volume::VolumeError;
+use crate::transform::{
+    Crop, HandleVolume, Padding, PaddingDirection, Resize, Transform, VolumeHandler,
+};
+
+#[derive(Debug, Snafu)]
+pub enum SaveError {
+    MissingProperty {
+        name: &'static str,
+    },
+    CastPropertyValue {
+        name: &'static str,
+        #[snafu(source(from(dicom::core::value::CastValueError, Box::new)))]
+        source: Box<dicom::core::value::CastValueError>,
+    },
+    #[snafu(display("could not open TIFF file {}", path.display()))]
+    CreateFile {
+        #[snafu(source(from(std::io::Error, Box::new)))]
+        source: Box<std::io::Error>,
+        path: PathBuf,
+    },
+    #[snafu(display("could not open TIFF file {}", path.display()))]
+    OpenTiff {
+        #[snafu(source(from(TiffError, Box::new)))]
+        source: Box<TiffError>,
+        path: PathBuf,
+    },
+    WriteToTiff {
+        #[snafu(source(from(TiffError, Box::new)))]
+        source: Box<TiffError>,
+    },
+    ConvertImageToBytes,
+    WriteTags {
+        #[snafu(source(from(TiffError, Box::new)))]
+        source: Box<TiffError>,
+    },
+}
+
+// Trait for saving a DynamicImage to a TIFF via a TiffEncoder under a given color type and compression
+pub trait SaveToTiff<C, D>
+where
+    C: ColorType,
+    D: Compression + Clone,
+{
+    fn save(
+        &self,
+        encoder: &mut TiffEncoder<File>,
+        image: &DynamicImage,
+        metadata: &PreprocessingMetadata,
+        compression: D,
+    ) -> Result<(), SaveError>;
+
+    fn save_all(
+        &self,
+        frames: Vec<DynamicImage>,
+        metadata: PreprocessingMetadata,
+        output: PathBuf,
+        compression: D,
+    ) -> Result<(), SaveError> {
+        // Open the TIFF file
+        let file = File::create(&output).context(CreateFileSnafu {
+            path: output.clone(),
+        })?;
+        let mut tiff_encoder = TiffEncoder::new(file).context(OpenTiffSnafu {
+            path: output.clone(),
+        })?;
+
+        for img in frames.iter() {
+            self.save(&mut tiff_encoder, img, &metadata, compression.clone())?;
+        }
+        Ok(())
+    }
+}
+
+pub struct TiffSaver {
+    compressor: Compressor,
+    color: DicomColorType,
+}
+
+/// Implement supported combinations of color type and compression
+macro_rules! impl_save_frame {
+    ($color_type:ty, $compression:ty, $as_fn:ident) => {
+        impl SaveToTiff<$color_type, $compression> for TiffSaver {
+            fn save(
+                &self,
+                encoder: &mut TiffEncoder<File>,
+                image: &DynamicImage,
+                metadata: &PreprocessingMetadata,
+                compression: $compression,
+            ) -> Result<(), SaveError> {
+                let (columns, rows) = image.dimensions();
+                let mut tiff = encoder
+                    .new_image_with_compression::<$color_type, _>(columns, rows, compression)
+                    .context(WriteToTiffSnafu)?;
+
+                metadata
+                    .write_tags(&mut tiff)
+                    .map_err(|e| SaveError::WriteTags {
+                        source: Box::new(e),
+                    })?;
+                let bytes = image.$as_fn().ok_or(SaveError::ConvertImageToBytes)?;
+                tiff.write_data(bytes).context(WriteToTiffSnafu)?;
+                Ok(())
+            }
+        }
+    };
+}
+
+// Implementations for Gray16
+impl_save_frame!(Gray16, Uncompressed, as_luma16);
+impl_save_frame!(Gray16, Packbits, as_luma16);
+impl_save_frame!(Gray16, Lzw, as_luma16);
+impl_save_frame!(Gray16, Deflate, as_luma16);
+
+// Implementations for RGB8
+impl_save_frame!(RGB8, Uncompressed, as_rgb8);
+impl_save_frame!(RGB8, Packbits, as_rgb8);
+impl_save_frame!(RGB8, Lzw, as_rgb8);
+impl_save_frame!(RGB8, Deflate, as_rgb8);
+
+impl TiffSaver {
+    pub fn new(compressor: Compressor, color: DicomColorType) -> Self {
+        Self { compressor, color }
+    }
+
+    pub fn save(
+        &self,
+        encoder: &mut TiffEncoder<File>,
+        image: &DynamicImage,
+        metadata: &PreprocessingMetadata,
+    ) -> Result<(), SaveError> {
+        match (&self.color, &self.compressor) {
+            (DicomColorType::Gray16(_), Compressor::Uncompressed(c)) => {
+                <TiffSaver as SaveToTiff<Gray16, Uncompressed>>::save(
+                    self, encoder, image, metadata, *c,
+                )
+            }
+            (DicomColorType::Gray16(_), Compressor::Packbits(c)) => {
+                <TiffSaver as SaveToTiff<Gray16, Packbits>>::save(
+                    self, encoder, image, metadata, *c,
+                )
+            }
+            (DicomColorType::Gray16(_), Compressor::Lzw(c)) => {
+                <TiffSaver as SaveToTiff<Gray16, Lzw>>::save(self, encoder, image, metadata, *c)
+            }
+            (DicomColorType::Gray16(_), Compressor::Deflate(c)) => {
+                <TiffSaver as SaveToTiff<Gray16, Deflate>>::save(self, encoder, image, metadata, *c)
+            }
+            (DicomColorType::RGB8(_), Compressor::Uncompressed(c)) => {
+                <TiffSaver as SaveToTiff<RGB8, Uncompressed>>::save(
+                    self, encoder, image, metadata, *c,
+                )
+            }
+            (DicomColorType::RGB8(_), Compressor::Packbits(c)) => {
+                <TiffSaver as SaveToTiff<RGB8, Packbits>>::save(self, encoder, image, metadata, *c)
+            }
+            (DicomColorType::RGB8(_), Compressor::Lzw(c)) => {
+                <TiffSaver as SaveToTiff<RGB8, Lzw>>::save(self, encoder, image, metadata, *c)
+            }
+            (DicomColorType::RGB8(_), Compressor::Deflate(c)) => {
+                <TiffSaver as SaveToTiff<RGB8, Deflate>>::save(self, encoder, image, metadata, *c)
+            }
+        }
+    }
+
+    pub fn save_all(
+        &self,
+        frames: Vec<DynamicImage>,
+        metadata: PreprocessingMetadata,
+        output: &PathBuf,
+    ) -> Result<(), SaveError> {
+        // Open the TIFF file
+        let file = File::create(&output).context(CreateFileSnafu {
+            path: output.clone(),
+        })?;
+        let mut tiff_encoder = TiffEncoder::new(file).context(OpenTiffSnafu {
+            path: output.clone(),
+        })?;
+
+        for img in frames.iter() {
+            self.save(&mut tiff_encoder, img, &metadata)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SaveToTiff, TiffSaver};
+    use crate::color::DicomColorType;
+    use crate::metadata::PreprocessingMetadata;
+    use crate::DisplayFilterType;
+    use crate::PaddingDirection;
+    use dicom::dictionary_std::tags;
+    use dicom::object::open_file;
+    use dicom_pixeldata::PixelDecoder;
+    use rstest::rstest;
+    use std::fs::File;
+    use std::io::BufReader;
+    use tiff::decoder::Decoder;
+    use tiff::encoder::compression::{Compressor, Uncompressed};
+
+    use tiff::tags::ResolutionUnit;
+    use tiff::tags::Tag;
+
+    #[rstest]
+    #[case("pydicom/CT_small.dcm", Compressor::Uncompressed(Uncompressed))]
+    fn test_save(#[case] dicom_file: &str, #[case] compressor: Compressor) {
+        // Open the DICOM file
+        let dicom_file = dicom_test_files::path(dicom_file).unwrap();
+        let dicom_file = open_file(&dicom_file).unwrap();
+
+        // Decode DICOM to DynamicImage
+        let image = dicom_file
+            .decode_pixel_data()
+            .unwrap()
+            .to_dynamic_image(0)
+            .unwrap();
+
+        // Determine the color type and create a saver with the given compressor
+        let color = DicomColorType::try_from(&dicom_file).unwrap();
+        let saver = TiffSaver::new(compressor, color);
+
+        // Create a temp directory for the TIFF output
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path().join("output.tiff");
+
+        // Create dummy metadata
+        let metadata = PreprocessingMetadata {
+            crop: None,
+            resize: None,
+            padding: None,
+            resolution: None,
+        };
+
+        saver.save_all(vec![image], metadata, &temp_path).unwrap();
+
+        // Check the output file exists
+        assert!(temp_path.exists());
+    }
+}

--- a/src/save.rs
+++ b/src/save.rs
@@ -178,7 +178,7 @@ impl TiffSaver {
         &self,
         frames: Vec<DynamicImage>,
         metadata: PreprocessingMetadata,
-        output: &PathBuf,
+        output: PathBuf,
     ) -> Result<(), SaveError> {
         // Open the TIFF file
         let file = File::create(&output).context(CreateFileSnafu {
@@ -237,7 +237,9 @@ mod tests {
             resolution: None,
         };
 
-        saver.save_all(vec![image], metadata, &temp_path).unwrap();
+        saver
+            .save_all(vec![image], metadata, temp_path.clone())
+            .unwrap();
 
         // Check the output file exists
         assert!(temp_path.exists());

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,27 +1,18 @@
 use image::DynamicImage;
 use image::GenericImageView;
 use std::fs::File;
-use std::io::Write;
 use std::path::PathBuf;
 use tiff::encoder::colortype::ColorType;
 use tiff::encoder::compression::{Compression, Compressor, Deflate, Packbits};
 use tiff::encoder::TiffEncoder;
 use tiff::TiffError;
 
-use dicom::dictionary_std::tags;
-use dicom::object::{FileDicomObject, InMemDicomObject, ReadError};
-use dicom::pixeldata::PhotometricInterpretation;
-use image::imageops::FilterType;
 use snafu::{ResultExt, Snafu};
 use tiff::encoder::colortype::{Gray16, RGB8};
 use tiff::encoder::compression::{Lzw, Uncompressed};
 
-use crate::color::{ColorError, DicomColorType};
-use crate::metadata::{PreprocessingMetadata, Resolution, WriteTags};
-use crate::transform::volume::VolumeError;
-use crate::transform::{
-    Crop, HandleVolume, Padding, PaddingDirection, Resize, Transform, VolumeHandler,
-};
+use crate::color::DicomColorType;
+use crate::metadata::{PreprocessingMetadata, WriteTags};
 
 #[derive(Debug, Snafu)]
 pub enum SaveError {
@@ -206,22 +197,15 @@ impl TiffSaver {
 
 #[cfg(test)]
 mod tests {
-    use super::{SaveToTiff, TiffSaver};
+    use super::TiffSaver;
     use crate::color::DicomColorType;
     use crate::metadata::PreprocessingMetadata;
-    use crate::DisplayFilterType;
-    use crate::PaddingDirection;
-    use dicom::dictionary_std::tags;
+
     use dicom::object::open_file;
     use dicom_pixeldata::PixelDecoder;
     use rstest::rstest;
-    use std::fs::File;
-    use std::io::BufReader;
-    use tiff::decoder::Decoder;
-    use tiff::encoder::compression::{Compressor, Uncompressed};
 
-    use tiff::tags::ResolutionUnit;
-    use tiff::tags::Tag;
+    use tiff::encoder::compression::{Compressor, Uncompressed};
 
     #[rstest]
     #[case("pydicom/CT_small.dcm", Compressor::Uncompressed(Uncompressed))]

--- a/src/transform/crop.rs
+++ b/src/transform/crop.rs
@@ -231,6 +231,7 @@ where
 {
     type Error = CropError;
 
+    /// Read the crop metadata from a TIFF file
     fn try_from(decoder: &mut Decoder<T>) -> Result<Self, Self::Error> {
         // Read and parse crop origin
         let origin = decoder

--- a/src/transform/crop.rs
+++ b/src/transform/crop.rs
@@ -1,5 +1,7 @@
 use image::{DynamicImage, GenericImageView, Pixel};
-use std::io::{Seek, Write};
+use snafu::{ResultExt, Snafu};
+use std::io::{Read, Seek, Write};
+use tiff::decoder::Decoder;
 use tiff::encoder::colortype::ColorType;
 use tiff::encoder::compression::Compression;
 use tiff::encoder::ImageEncoder;
@@ -13,6 +15,19 @@ use crate::transform::Transform;
 pub const DEFAULT_CROP_ORIGIN: u16 = 50719;
 pub const DEFAULT_CROP_SIZE: u16 = 50720;
 const DEFAULT_CHECK_MAX: bool = false;
+
+#[derive(Debug, Snafu)]
+pub enum CropError {
+    ReadTiffTag {
+        name: &'static str,
+        #[snafu(source(from(TiffError, Box::new)))]
+        source: Box<TiffError>,
+    },
+    InvalidTagLength {
+        name: &'static str,
+        size: usize,
+    },
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Crop {
@@ -210,11 +225,62 @@ impl WriteTags for Crop {
     }
 }
 
+impl<T> TryFrom<&mut Decoder<T>> for Crop
+where
+    T: Read + Seek,
+{
+    type Error = CropError;
+
+    fn try_from(decoder: &mut Decoder<T>) -> Result<Self, Self::Error> {
+        // Read and parse crop origin
+        let origin = decoder
+            .get_tag_u32_vec(Tag::Unknown(DEFAULT_CROP_ORIGIN))
+            .context(ReadTiffTagSnafu {
+                name: "DefaultCropOrigin",
+            })?;
+        if origin.len() != 2 {
+            return Err(CropError::InvalidTagLength {
+                name: "DefaultCropOrigin",
+                size: origin.len(),
+            });
+        }
+        let (origin_x, origin_y) = (origin[0], origin[1]);
+
+        // Read and parse crop size
+        let size = decoder
+            .get_tag_u32_vec(Tag::Unknown(DEFAULT_CROP_SIZE))
+            .context(ReadTiffTagSnafu {
+                name: "DefaultCropSize",
+            })?;
+        if size.len() != 2 {
+            return Err(CropError::InvalidTagLength {
+                name: "DefaultCropSize",
+                size: size.len(),
+            });
+        }
+        let (width, height) = (size[0], size[1]);
+
+        // Build final result
+        let top = origin_y - height / 2;
+        let left = origin_x - width / 2;
+        Ok(Crop {
+            top,
+            left,
+            width,
+            height,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use image::{DynamicImage, RgbaImage};
     use rstest::rstest;
+    use std::fs::File;
+    use tempfile::tempdir;
+    use tiff::decoder::Decoder as TiffDecoder;
+    use tiff::encoder::TiffEncoder;
 
     #[rstest]
     #[case(
@@ -332,5 +398,29 @@ mod tests {
     fn test_intersection(#[case] crop1: Crop, #[case] crop2: Crop, #[case] expected: Crop) {
         let result = crop1.intersection(&crop2);
         assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case(Crop { left: 1, top: 1, width: 2, height: 2 })]
+    fn test_write_tags(#[case] crop: Crop) {
+        // Prepare the TIFF
+        let temp_dir = tempdir().unwrap();
+        let temp_file_path = temp_dir.path().join("temp.tif");
+        let mut tiff = TiffEncoder::new(File::create(temp_file_path.clone()).unwrap()).unwrap();
+        let mut img = tiff
+            .new_image::<tiff::encoder::colortype::Gray16>(1, 1)
+            .unwrap();
+
+        // Write the tags
+        crop.write_tags(&mut img).unwrap();
+
+        // Write some dummy image data
+        let data: Vec<u16> = vec![0; 2];
+        img.write_data(data.as_slice()).unwrap();
+
+        // Read the TIFF back
+        let mut tiff = TiffDecoder::new(File::open(temp_file_path).unwrap()).unwrap();
+        let actual = Crop::try_from(&mut tiff).unwrap();
+        assert_eq!(crop, actual);
     }
 }

--- a/src/transform/pad.rs
+++ b/src/transform/pad.rs
@@ -167,6 +167,7 @@ where
 {
     type Error = PaddingError;
 
+    /// Read the padding metadata from a TIFF file
     fn try_from(decoder: &mut Decoder<T>) -> Result<Self, Self::Error> {
         let active_area = decoder
             .get_tag_u32_vec(Tag::Unknown(ACTIVE_AREA))

--- a/src/transform/resize.rs
+++ b/src/transform/resize.rs
@@ -52,21 +52,9 @@ impl fmt::Display for DisplayFilterType {
     }
 }
 
-impl From<FilterType> for DisplayFilterType {
-    fn from(filter: FilterType) -> Self {
+impl From<DisplayFilterType> for FilterType {
+    fn from(filter: DisplayFilterType) -> Self {
         match filter {
-            FilterType::Nearest => DisplayFilterType::Nearest,
-            FilterType::Triangle => DisplayFilterType::Triangle,
-            FilterType::CatmullRom => DisplayFilterType::CatmullRom,
-            FilterType::Gaussian => DisplayFilterType::Gaussian,
-            FilterType::Lanczos3 => DisplayFilterType::Lanczos3,
-        }
-    }
-}
-
-impl Into<FilterType> for DisplayFilterType {
-    fn into(self) -> FilterType {
-        match self {
             DisplayFilterType::Nearest => FilterType::Nearest,
             DisplayFilterType::Triangle => FilterType::Triangle,
             DisplayFilterType::CatmullRom => FilterType::CatmullRom,
@@ -92,17 +80,11 @@ impl Resize {
     ) -> Self {
         // Determine scale factors
         let (width, height) = image.dimensions();
-        let scale_x = target_width as f32 / width as f32;
-        let scale_y = target_height as f32 / height as f32;
-
-        // Preserve aspect ratio by choosing the smaller scale factor
-        let scale = scale_x.min(scale_y);
-        let scale_x = scale;
-        let scale_y = scale;
+        let scale = (target_width as f32 / width as f32).min(target_height as f32 / height as f32);
 
         Resize {
-            scale_x,
-            scale_y,
+            scale_x: scale,
+            scale_y: scale,
             filter,
         }
     }
@@ -121,7 +103,8 @@ impl Transform<Resolution> for Resize {
     fn apply(&self, resolution: &Resolution) -> Resolution {
         assert_eq!(
             self.scale_x, self.scale_y,
-            "Expected scale_x and scale_y to be equal"
+            "Expected scale_x and scale_y to be equal: {} {}",
+            self.scale_x, self.scale_y
         );
         let scale = self.scale_x;
         resolution.scale(scale)

--- a/src/transform/resize.rs
+++ b/src/transform/resize.rs
@@ -149,6 +149,7 @@ where
 {
     type Error = ResizeError;
 
+    /// Read the resize metadata from a TIFF file
     fn try_from(decoder: &mut Decoder<T>) -> Result<Self, Self::Error> {
         let scale = decoder
             .get_tag_f32_vec(Tag::Unknown(DEFAULT_SCALE))

--- a/src/transform/volume.rs
+++ b/src/transform/volume.rs
@@ -49,6 +49,12 @@ pub enum VolumeHandler {
     MaxIntensity(MaxIntensity),
 }
 
+impl Default for VolumeHandler {
+    fn default() -> Self {
+        VolumeHandler::Keep(KeepVolume)
+    }
+}
+
 #[derive(Default, Debug, Clone, Copy, clap::ValueEnum)]
 pub enum DisplayVolumeHandler {
     #[default]


### PR DESCRIPTION
Does the following:
* Isolates preprocessing functionality from saving to TIFF functionality to support Python bindings that operate entirely in memory
* Refactors transforms and adds abstractions to reconstruct transforms from TIFF tags
* Creates a separate module / abstraction for mapping DICOM tags to expected TIFF color types
* Remove unused Snafus
* Clean up template resolution for TiffEncoder from DICOM tags and compression options
* Add / improve tests