### PR TITLE
Track number of frames in TIFF tag

### DIFF
--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -120,6 +120,8 @@ impl Preprocessor {
             None => image_data,
         };
 
+        let num_frames = image_data.len().into();
+
         Ok((
             image_data,
             PreprocessingMetadata {
@@ -127,6 +129,7 @@ impl Preprocessor {
                 resize: resize_config,
                 padding: padding_config,
                 resolution,
+                num_frames,
             },
         ))
     }

--- a/src/save.rs
+++ b/src/save.rs
@@ -223,7 +223,7 @@ mod tests {
             resize: None,
             padding: None,
             resolution: None,
-            num_frames: (1 as u32).into(),
+            num_frames: (1 as u16).into(),
         };
 
         let mut encoder = saver.open_tiff(temp_path.clone()).unwrap();

--- a/src/save.rs
+++ b/src/save.rs
@@ -223,6 +223,7 @@ mod tests {
             resize: None,
             padding: None,
             resolution: None,
+            num_frames: (1 as u32).into(),
         };
 
         let mut encoder = saver.open_tiff(temp_path.clone()).unwrap();


### PR DESCRIPTION
The `PageNumber` field is used to track the total number of frames in the TIFF.