### PR TITLE
Support frame-parallelism in decoding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -304,7 +304,7 @@ fn process(
     dest: &PathBuf,
     preprocessor: &Preprocessor,
     compressor: SupportedCompressor,
-    parallelism: usize,
+    parallelism: bool,
 ) -> Result<(), Error> {
     let file = open_file(&source).context(DicomReadSnafu { path: source })?;
 
@@ -363,11 +363,11 @@ fn process(
 /// Determines the number of threads to use for parallel processing for multi-frame DICOM files.
 /// Frame parallelism will only be used when the number of inputs is small. Otherwise, it as assumed
 /// that file parallelism is desired and only a single thread is used for a given file.
-fn determine_parallelism(num_inputs: usize) -> usize {
+fn determine_parallelism(num_inputs: usize) -> bool {
     let max_parallelism = available_parallelism()
         .unwrap_or(NonZero::new(1).unwrap())
         .get();
-    (max_parallelism / num_inputs).max(1)
+    (max_parallelism / num_inputs).max(1) > 1
 }
 
 fn run(args: Args) -> Result<(), Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,9 @@ use dicom_preprocessing::resize::DisplayFilterType;
 use indicatif::{ProgressBar, ProgressStyle};
 use rust_search::SearchBuilder;
 use snafu::{OptionExt, Report, ResultExt, Snafu, Whatever};
+use std::num::NonZero;
 use std::path::Path;
+use std::thread::available_parallelism;
 
 use dicom_preprocessing::color::ColorError;
 use dicom_preprocessing::preprocess::PreprocessError;
@@ -302,6 +304,7 @@ fn process(
     dest: &PathBuf,
     preprocessor: &Preprocessor,
     compressor: SupportedCompressor,
+    parallelism: usize,
 ) -> Result<(), Error> {
     let file = open_file(&source).context(DicomReadSnafu { path: source })?;
 
@@ -343,7 +346,7 @@ fn process(
 
     tracing::info!("Processing {} -> {}", source.display(), dest.display());
     let (images, metadata) = preprocessor
-        .prepare_image(&file)
+        .prepare_image(&file, parallelism)
         .context(PreprocessingSnafu)?;
     let color_type = DicomColorType::try_from(&file).context(ColorTypeSnafu)?;
 
@@ -355,6 +358,16 @@ fn process(
         .context(SaveToTiffSnafu)?;
 
     Ok(())
+}
+
+/// Determines the number of threads to use for parallel processing for multi-frame DICOM files.
+/// Frame parallelism will only be used when the number of inputs is small. Otherwise, it as assumed
+/// that file parallelism is desired and only a single thread is used for a given file.
+fn determine_parallelism(num_inputs: usize) -> usize {
+    let max_parallelism = available_parallelism()
+        .unwrap_or(NonZero::new(1).unwrap())
+        .get();
+    (max_parallelism / num_inputs).max(1)
 }
 
 fn run(args: Args) -> Result<(), Error> {
@@ -404,8 +417,9 @@ fn run(args: Args) -> Result<(), Error> {
     pb.set_message("Preprocessing DICOM files");
 
     // Process each file in parallel
+    let parallelism = determine_parallelism(source.len());
     source.into_par_iter().try_for_each(|file| {
-        let result = process(&file, &dest, &preprocessor, compressor.clone());
+        let result = process(&file, &dest, &preprocessor, compressor.clone(), parallelism);
         pb.inc(1);
         result
     })?;

--- a/src/transform/volume.rs
+++ b/src/transform/volume.rs
@@ -44,6 +44,7 @@ pub enum VolumeError {
     },
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum VolumeHandler {
     Keep(KeepVolume),
     CentralSlice(CentralSlice),
@@ -144,6 +145,7 @@ impl HandleVolume for VolumeHandler {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct KeepVolume;
 
 impl HandleVolume for KeepVolume {
@@ -182,6 +184,7 @@ impl HandleVolume for KeepVolume {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct CentralSlice;
 
 impl HandleVolume for CentralSlice {
@@ -207,6 +210,7 @@ impl HandleVolume for CentralSlice {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct MaxIntensity {
     skip_start: u32,
     skip_end: u32,

--- a/src/transform/volume.rs
+++ b/src/transform/volume.rs
@@ -4,6 +4,7 @@ use dicom::pixeldata::PixelDecoder;
 use image::DynamicImage;
 use image::Pixel;
 use image::{GenericImage, GenericImageView};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use snafu::{ResultExt, Snafu};
 use std::cmp::{max, min};
 use std::fmt;
@@ -87,7 +88,7 @@ impl fmt::Display for DisplayVolumeHandler {
     }
 }
 
-fn get_number_of_frames(file: &FileDicomObject<InMemDicomObject>) -> Result<u32, VolumeError> {
+pub fn get_number_of_frames(file: &FileDicomObject<InMemDicomObject>) -> Result<u32, VolumeError> {
     let number_of_frames = file.get(tags::NUMBER_OF_FRAMES);
 
     let number_of_frames = match number_of_frames {
@@ -106,7 +107,14 @@ fn get_number_of_frames(file: &FileDicomObject<InMemDicomObject>) -> Result<u32,
 }
 
 pub trait HandleVolume {
+    /// Decode and handle the volume frame by frame
     fn decode_volume(
+        &self,
+        file: &FileDicomObject<InMemDicomObject>,
+    ) -> Result<Vec<DynamicImage>, VolumeError>;
+
+    /// Decode each frame in parallel and handle the volume
+    fn par_decode_volume(
         &self,
         file: &FileDicomObject<InMemDicomObject>,
     ) -> Result<Vec<DynamicImage>, VolumeError>;
@@ -121,6 +129,17 @@ impl HandleVolume for VolumeHandler {
             VolumeHandler::Keep(handler) => handler.decode_volume(file),
             VolumeHandler::CentralSlice(handler) => handler.decode_volume(file),
             VolumeHandler::MaxIntensity(handler) => handler.decode_volume(file),
+        }
+    }
+
+    fn par_decode_volume(
+        &self,
+        file: &FileDicomObject<InMemDicomObject>,
+    ) -> Result<Vec<DynamicImage>, VolumeError> {
+        match self {
+            VolumeHandler::Keep(handler) => handler.par_decode_volume(file),
+            VolumeHandler::CentralSlice(handler) => handler.par_decode_volume(file),
+            VolumeHandler::MaxIntensity(handler) => handler.par_decode_volume(file),
         }
     }
 }
@@ -142,6 +161,25 @@ impl HandleVolume for KeepVolume {
         }
         Ok(image_data)
     }
+
+    fn par_decode_volume(
+        &self,
+        file: &FileDicomObject<InMemDicomObject>,
+    ) -> Result<Vec<DynamicImage>, VolumeError> {
+        let number_of_frames = get_number_of_frames(file)?;
+        let result = (0..number_of_frames)
+            .into_par_iter()
+            .map(|frame| {
+                let result = file
+                    .decode_pixel_data_frame(frame)
+                    .context(DecodePixelDataSnafu)?
+                    .to_dynamic_image(0)
+                    .context(DecodePixelDataSnafu)?;
+                Ok(result)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(result)
+    }
 }
 
 pub struct CentralSlice;
@@ -159,11 +197,35 @@ impl HandleVolume for CentralSlice {
         let image = decoded.to_dynamic_image(0).context(DecodePixelDataSnafu)?;
         Ok(vec![image])
     }
+
+    fn par_decode_volume(
+        &self,
+        file: &FileDicomObject<InMemDicomObject>,
+    ) -> Result<Vec<DynamicImage>, VolumeError> {
+        // Since there is only one frame, we can just decode it serially
+        self.decode_volume(file)
+    }
 }
 
 pub struct MaxIntensity {
     skip_start: u32,
     skip_end: u32,
+}
+
+impl MaxIntensity {
+    fn reduce(current: DynamicImage, new: DynamicImage) -> DynamicImage {
+        let mut current = current;
+        let (width, height) = current.dimensions();
+        for x in 0..width {
+            for y in 0..height {
+                let mut current_pixel = current.get_pixel(x, y);
+                let new_pixel = new.get_pixel(x, y);
+                current_pixel.apply2(&new_pixel, |p1, p2| max(p1, p2));
+                current.put_pixel(x, y, current_pixel);
+            }
+        }
+        current
+    }
 }
 
 impl HandleVolume for MaxIntensity {
@@ -187,24 +249,56 @@ impl HandleVolume for MaxIntensity {
         let decoded = file
             .decode_pixel_data_frame(start)
             .context(DecodePixelDataSnafu)?;
-        let mut image = decoded.to_dynamic_image(0).context(DecodePixelDataSnafu)?;
-        let (width, height) = image.dimensions();
 
+        let mut image = decoded.to_dynamic_image(0).context(DecodePixelDataSnafu)?;
         for frame_number in (start + 1)..end {
             let decoded = file
                 .decode_pixel_data_frame(frame_number)
                 .context(DecodePixelDataSnafu)?;
             let frame = decoded.to_dynamic_image(0).context(DecodePixelDataSnafu)?;
-            for x in 0..width {
-                for y in 0..height {
-                    let mut current_pixel = image.get_pixel(x, y);
-                    let frame_pixel = frame.get_pixel(x, y);
-                    current_pixel.apply2(&frame_pixel, |p1, p2| max(p1, p2));
-                    image.put_pixel(x, y, current_pixel);
-                }
-            }
+            image = Self::reduce(image, frame);
         }
         Ok(vec![image])
+    }
+
+    fn par_decode_volume(
+        &self,
+        file: &FileDicomObject<InMemDicomObject>,
+    ) -> Result<Vec<DynamicImage>, VolumeError> {
+        let number_of_frames = get_number_of_frames(file)?;
+        let start = min(number_of_frames, self.skip_start);
+        let end = max(0, number_of_frames - self.skip_end);
+
+        // Validate the start/end relative to the number of frames
+        if start >= end || start >= number_of_frames || end <= 0 {
+            return Err(VolumeError::InvalidVolumeRange {
+                start,
+                end,
+                number_of_frames,
+            });
+        }
+
+        let image = (start..end)
+            .into_par_iter()
+            .map(|frame_number| {
+                let frame = file
+                    .decode_pixel_data_frame(frame_number)
+                    .context(DecodePixelDataSnafu)?
+                    .to_dynamic_image(0)
+                    .context(DecodePixelDataSnafu)?;
+                Ok::<DynamicImage, VolumeError>(frame)
+            })
+            .try_reduce_with(|image, frame| Ok(Self::reduce(image, frame)));
+
+        if let Some(image) = image {
+            Ok(vec![image?])
+        } else {
+            Err(VolumeError::InvalidVolumeRange {
+                start,
+                end,
+                number_of_frames,
+            })
+        }
     }
 }
 
@@ -227,6 +321,21 @@ mod tests {
         let dicom = dicom_test_files::path(dicom_file_path).unwrap();
         let dicom = open_file(&dicom).unwrap();
         let images = volume_handler.decode_volume(&dicom).unwrap();
+        assert_eq!(images.len() as u32, expected_number_of_frames);
+    }
+
+    #[rstest]
+    #[case("pydicom/CT_small.dcm", VolumeHandler::Keep(KeepVolume), 1)]
+    #[case("pydicom/CT_small.dcm", VolumeHandler::CentralSlice(CentralSlice), 1)]
+    #[case("pydicom/CT_small.dcm", VolumeHandler::MaxIntensity(MaxIntensity { skip_start: 0, skip_end: 0 }), 1)]
+    fn test_par_decode_volume(
+        #[case] dicom_file_path: &str,
+        #[case] volume_handler: VolumeHandler,
+        #[case] expected_number_of_frames: u32,
+    ) {
+        let dicom = dicom_test_files::path(dicom_file_path).unwrap();
+        let dicom = open_file(&dicom).unwrap();
+        let images = volume_handler.par_decode_volume(&dicom).unwrap();
         assert_eq!(images.len() as u32, expected_number_of_frames);
     }
 }


### PR DESCRIPTION
For bulk preprocessing, parallelism over the input files is typically sufficient to achieve high throughput. Yet for small batch preprocessing (as one might encounter in production), volume decoding ends up being bound to a single thread. This PR adds support for parallelizing the decode across frames. Logic as added to the CLI to dynamically transition between file and frame parallelism depending on the number of inputs.

Under this change the decode time for JPEG2000 DBT volumes can be reduced to ~3s on CPU.