### PR TITLE
Improve error handling

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -7,16 +7,18 @@ use tiff::encoder::colortype::{Gray16, Gray8, RGB8};
 #[derive(Debug, Snafu)]
 pub enum ColorError {
     #[snafu(display("Missing property: {}", name))]
-    MissingProperty {
-        name: &'static str,
-    },
+    MissingProperty { name: &'static str },
     #[snafu(display("Invalid property value: {}", name))]
     CastPropertyValue {
         name: &'static str,
         #[snafu(source(from(dicom::core::value::CastValueError, Box::new)))]
         source: Box<dicom::core::value::CastValueError>,
     },
-    #[snafu(display("Unsupported photometric interpretation: {}, {}", bits_allocated, photometric_interpretation))]
+    #[snafu(display(
+        "Unsupported photometric interpretation: {}, {}",
+        bits_allocated,
+        photometric_interpretation
+    ))]
     UnsupportedPhotometricInterpretation {
         bits_allocated: u16,
         photometric_interpretation: PhotometricInterpretation,

--- a/src/color.rs
+++ b/src/color.rs
@@ -6,14 +6,17 @@ use tiff::encoder::colortype::{Gray16, Gray8, RGB8};
 
 #[derive(Debug, Snafu)]
 pub enum ColorError {
+    #[snafu(display("Missing property: {}", name))]
     MissingProperty {
         name: &'static str,
     },
+    #[snafu(display("Invalid property value: {}", name))]
     CastPropertyValue {
         name: &'static str,
         #[snafu(source(from(dicom::core::value::CastValueError, Box::new)))]
         source: Box<dicom::core::value::CastValueError>,
     },
+    #[snafu(display("Unsupported photometric interpretation: {}, {}", bits_allocated, photometric_interpretation))]
     UnsupportedPhotometricInterpretation {
         bits_allocated: u16,
         photometric_interpretation: PhotometricInterpretation,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,9 @@ pub enum Error {
         #[snafu(source(from(ReadError, Box::new)))]
         source: Box<ReadError>,
     },
-    /// missing key property {name}
+    #[snafu(display("Missing property: {}", name))]
     MissingProperty { name: &'static str },
-    /// property {name} contains an invalid value
+    #[snafu(display("Invalid property value: {}", name))]
     InvalidPropertyValue {
         name: &'static str,
         #[snafu(source(from(dicom::core::value::ConvertValueError, Box::new)))]
@@ -53,6 +53,7 @@ pub enum Error {
         #[snafu(source(from(PreprocessError, Box::new)))]
         source: Box<PreprocessError>,
     },
+    #[snafu(display("Failed to create directory: {}", path.display()))]
     CreateDir {
         path: PathBuf,
         #[snafu(source(from(std::io::Error, Box::new)))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,11 @@ fn run(args: Args) -> Result<(), Error> {
         match result {
             Ok(result) => Ok(result),
             Err(e) => {
-                error!("Error processing file {}: {}", file.display(), Report::from_error(&e));
+                error!(
+                    "Error processing file {}: {}",
+                    file.display(),
+                    Report::from_error(&e)
+                );
                 Err(e)
             }
         }

--- a/src/save.rs
+++ b/src/save.rs
@@ -17,15 +17,17 @@ use crate::metadata::{PreprocessingMetadata, WriteTags};
 
 #[derive(Debug, Snafu)]
 pub enum SaveError {
+    #[snafu(display("Missing property: {}", name))]
     MissingProperty {
         name: &'static str,
     },
+    #[snafu(display("Invalid property value: {}", name))]
     CastPropertyValue {
         name: &'static str,
         #[snafu(source(from(dicom::core::value::CastValueError, Box::new)))]
         source: Box<dicom::core::value::CastValueError>,
     },
-    #[snafu(display("could not open TIFF file {}", path.display()))]
+    #[snafu(display("could not create TIFF file {}", path.display()))]
     CreateFile {
         #[snafu(source(from(std::io::Error, Box::new)))]
         source: Box<std::io::Error>,

--- a/src/transform/volume.rs
+++ b/src/transform/volume.rs
@@ -1,3 +1,4 @@
+use dicom::core::header::HasLength;
 use dicom::dictionary_std::tags;
 use dicom::object::{FileDicomObject, InMemDicomObject};
 use dicom::pixeldata::PixelDecoder;
@@ -11,9 +12,7 @@ use std::fmt;
 #[derive(Debug, Snafu)]
 pub enum VolumeError {
     #[snafu(display("Missing property: {}", name))]
-    MissingProperty {
-        name: &'static str,
-    },
+    MissingProperty { name: &'static str },
     #[snafu(display("Invalid property value: {}", name))]
     InvalidPropertyValue {
         name: &'static str,
@@ -21,9 +20,7 @@ pub enum VolumeError {
         source: Box<dicom::core::value::ConvertValueError>,
     },
     #[snafu(display("Invalid number of frames: {}", value))]
-    InvalidNumberOfFrames {
-        value: i32,
-    },
+    InvalidNumberOfFrames { value: i32 },
     #[snafu(display("Invalid property value: {}", name))]
     CastPropertyValue {
         name: &'static str,
@@ -95,9 +92,11 @@ fn get_number_of_frames(file: &FileDicomObject<InMemDicomObject>) -> Result<u32,
     let number_of_frames = file.get(tags::NUMBER_OF_FRAMES);
 
     let number_of_frames = match number_of_frames {
-        Some(elem) => elem.to_int::<i32>().context(InvalidPropertyValueSnafu {
-            name: "Number of Frames",
-        })?,
+        Some(elem) if !elem.is_empty() => {
+            elem.to_int::<i32>().context(InvalidPropertyValueSnafu {
+                name: "Number of Frames",
+            })?
+        }
         _ => 1,
     };
 

--- a/src/transform/volume.rs
+++ b/src/transform/volume.rs
@@ -10,17 +10,21 @@ use std::fmt;
 
 #[derive(Debug, Snafu)]
 pub enum VolumeError {
+    #[snafu(display("Missing property: {}", name))]
     MissingProperty {
         name: &'static str,
     },
+    #[snafu(display("Invalid property value: {}", name))]
     InvalidPropertyValue {
         name: &'static str,
         #[snafu(source(from(dicom::core::value::ConvertValueError, Box::new)))]
         source: Box<dicom::core::value::ConvertValueError>,
     },
+    #[snafu(display("Invalid number of frames: {}", value))]
     InvalidNumberOfFrames {
         value: i32,
     },
+    #[snafu(display("Invalid property value: {}", name))]
     CastPropertyValue {
         name: &'static str,
         #[snafu(source(from(dicom::core::value::CastValueError, Box::new)))]


### PR DESCRIPTION
Does the following:
1. When `--strict` is not set, errors are logged and the failing files are skipped
2. Improves display of error messages
3. Handles empty values for NumberOfFrames