### PR TITLE
Move `Dimensions` to standalone module

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -1,3 +1,4 @@
+use num::PrimInt;
 use std::io::{Read, Seek};
 use tiff::decoder::{Decoder, DecodingResult};
 

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,74 +1,11 @@
-use num::PrimInt;
 use std::io::{Read, Seek};
 use tiff::decoder::{Decoder, DecodingResult};
 
 use snafu::ResultExt;
 
-use crate::color::DicomColorType;
 use crate::errors::{tiff::SeekToFrameSnafu, TiffError};
-use crate::metadata::FrameCount;
+use crate::metadata::{Dimensions, FrameCount};
 use ndarray::{s, Array, Array4};
-
-/// The order of the channels in the loaded image
-#[derive(Clone, Copy, Debug)]
-pub enum ChannelOrder {
-    NHWC,
-    NCHW,
-}
-
-#[derive(Clone, Debug)]
-struct Dimensions {
-    width: usize,
-    height: usize,
-    num_frames: usize,
-    color_type: DicomColorType,
-}
-
-impl Dimensions {
-    pub fn shape(&self, channel_order: &ChannelOrder) -> (usize, usize, usize, usize) {
-        match channel_order {
-            ChannelOrder::NHWC => (
-                self.num_frames,
-                self.height,
-                self.width,
-                self.color_type.channels(),
-            ),
-            ChannelOrder::NCHW => (
-                self.num_frames,
-                self.color_type.channels(),
-                self.height,
-                self.width,
-            ),
-        }
-    }
-
-    pub fn frame_shape(&self, channel_order: &ChannelOrder) -> (usize, usize, usize) {
-        match channel_order {
-            ChannelOrder::NHWC => (self.height, self.width, self.color_type.channels()),
-            ChannelOrder::NCHW => (self.color_type.channels(), self.height, self.width),
-        }
-    }
-
-    pub fn with_num_frames(self, num_frames: usize) -> Self {
-        Dimensions { num_frames, ..self }
-    }
-}
-
-impl<R: Read + Seek> TryFrom<&mut Decoder<R>> for Dimensions {
-    type Error = TiffError;
-    fn try_from(decoder: &mut Decoder<R>) -> Result<Self, Self::Error> {
-        let (width, height) = decoder.dimensions()?;
-        let color_type = decoder.colortype()?;
-        let color_type = DicomColorType::try_from(color_type)?;
-        let num_frames: u16 = FrameCount::try_from(decoder)?.into();
-        Ok(Self {
-            width: width as usize,
-            height: height as usize,
-            num_frames: num_frames as usize,
-            color_type,
-        })
-    }
-}
 
 pub trait LoadFromTiff<T: Clone + num::Zero> {
     fn to_vec(decoded: DecodingResult) -> Result<Vec<T>, TiffError>;
@@ -83,8 +20,7 @@ pub trait LoadFromTiff<T: Clone + num::Zero> {
         // Determine dimensions of the loaded result, accounting for the selected frames subset
         // TODO: Support channel-first
         let dimensions = Dimensions::try_from(&mut *decoder)?;
-        let channel_order = ChannelOrder::NHWC;
-        let decoded_dimensions = dimensions.clone().with_num_frames(frames.len());
+        let decoded_dimensions = dimensions.with_num_frames(frames.len());
 
         // Validate that the requested frames are within the range of the TIFF file
         let max_frame = frames.iter().max().unwrap().clone();
@@ -105,13 +41,11 @@ pub trait LoadFromTiff<T: Clone + num::Zero> {
             })?;
             let image = decoder.read_image()?;
             let image = Self::to_vec(image)?;
-            return Ok(
-                Array::from_shape_vec(decoded_dimensions.shape(&channel_order), image).unwrap(),
-            );
+            return Ok(Array::from_shape_vec(decoded_dimensions.shape(), image).unwrap());
         }
 
         // Pre-allocate contiguous array and fill it with the decoded frames
-        let mut array = Array4::<T>::zeros(decoded_dimensions.shape(&channel_order));
+        let mut array = Array4::<T>::zeros(decoded_dimensions.shape());
         for (i, frame) in frames.into_iter().enumerate() {
             decoder.seek_to_image(frame).context(SeekToFrameSnafu {
                 frame,
@@ -123,8 +57,7 @@ pub trait LoadFromTiff<T: Clone + num::Zero> {
             let image = decoder.read_image()?;
             let image = Self::to_vec(image)?;
             let mut slice = array.slice_mut(s![i, .., .., ..]);
-            let new = Array::from_shape_vec(decoded_dimensions.frame_shape(&channel_order), image)
-                .unwrap();
+            let new = Array::from_shape_vec(decoded_dimensions.frame_shape(), image).unwrap();
             slice.assign(&new);
         }
 
@@ -188,6 +121,7 @@ mod tests {
     use std::io::BufReader;
     use tempfile;
 
+    use crate::color::DicomColorType;
     use crate::preprocess::Preprocessor;
     use crate::save::TiffSaver;
     use crate::transform::PaddingDirection;

--- a/src/metadata/dimensions.rs
+++ b/src/metadata/dimensions.rs
@@ -1,0 +1,152 @@
+use crate::metadata::FrameCount;
+use dicom::dictionary_std::tags;
+use dicom::object::{FileDicomObject, InMemDicomObject};
+use image::DynamicImage;
+use ndarray::{Dim, Shape};
+use num::PrimInt;
+use snafu::{ResultExt, Snafu};
+use std::io::{Read, Seek};
+use tiff::decoder::Decoder;
+
+use crate::color::DicomColorType;
+use crate::errors::{
+    dicom::{CastValueSnafu, ConvertValueSnafu, MissingPropertySnafu},
+    DicomError, TiffError,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub enum ChannelOrder {
+    NHWC,
+    NCHW,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Dimensions {
+    width: usize,
+    height: usize,
+    num_frames: usize,
+    channels: usize,
+    channel_order: ChannelOrder,
+}
+
+impl Dimensions {
+    fn new(
+        width: usize,
+        height: usize,
+        num_frames: usize,
+        channels: usize,
+        channel_order: ChannelOrder,
+    ) -> Self {
+        Self {
+            width,
+            height,
+            num_frames,
+            channels,
+            channel_order,
+        }
+    }
+
+    fn with_num_frames(self, num_frames: usize) -> Self {
+        Self { num_frames, ..self }
+    }
+
+    fn with_channel_order(self, channel_order: ChannelOrder) -> Self {
+        Self {
+            channel_order,
+            ..self
+        }
+    }
+}
+
+impl<T: PrimInt> Into<(T, T, T, T)> for Dimensions {
+    /// Returns the shape of the entire volume
+    fn into(self) -> (T, T, T, T) {
+        match self.channel_order {
+            ChannelOrder::NHWC => (
+                T::from(self.num_frames).unwrap(),
+                T::from(self.height).unwrap(),
+                T::from(self.width).unwrap(),
+                T::from(self.channels).unwrap(),
+            ),
+            ChannelOrder::NCHW => (
+                T::from(self.num_frames).unwrap(),
+                T::from(self.channels).unwrap(),
+                T::from(self.height).unwrap(),
+                T::from(self.width).unwrap(),
+            ),
+        }
+    }
+}
+
+impl<R: Read + Seek> TryFrom<&mut Decoder<R>> for Dimensions {
+    type Error = TiffError;
+    /// Extract dimensions from a TIFF decoder. Note that if the TIFF was not preprocessed,
+    /// this will require traversing the IFD chain to get the number of frames.
+    fn try_from(decoder: &mut Decoder<R>) -> Result<Self, Self::Error> {
+        let (width, height) = decoder.dimensions()?;
+        let color_type = decoder.colortype()?;
+        let color_type = DicomColorType::try_from(color_type)?;
+        let num_frames: u16 = FrameCount::try_from(decoder)?.into();
+        Ok(Self {
+            width: width as usize,
+            height: height as usize,
+            num_frames: num_frames as usize,
+            channels: color_type.channels(),
+            channel_order: ChannelOrder::NHWC,
+        })
+    }
+}
+
+impl TryFrom<&FileDicomObject<InMemDicomObject>> for Dimensions {
+    type Error = DicomError;
+    fn try_from(dcm: &FileDicomObject<InMemDicomObject>) -> Result<Self, Self::Error> {
+        let num_frames = FrameCount::try_from(dcm)?.into();
+        let rows = dcm
+            .get(tags::ROWS)
+            .ok_or(DicomError::MissingPropertyError { name: "Rows" })?
+            .value()
+            .to_int::<i32>()
+            .context(ConvertValueSnafu { name: "Rows" })? as usize;
+        let columns = dcm
+            .get(tags::COLUMNS)
+            .ok_or(DicomError::MissingPropertyError { name: "Columns" })?
+            .value()
+            .to_int::<i32>()
+            .context(ConvertValueSnafu { name: "Columns" })? as usize;
+        let color_type = DicomColorType::try_from(dcm)?;
+        Ok(Self {
+            num_frames,
+            height: rows,
+            width: columns,
+            channels: color_type.channels(),
+            channel_order: ChannelOrder::NHWC,
+        })
+    }
+}
+
+impl TryFrom<&DynamicImage> for Dimensions {
+    type Error = LoadError;
+    fn try_from(dcm: &FileDicomObject<InMemDicomObject>) -> Result<Self, Self::Error> {
+        let num_frames = FrameCount::try_from(dcm).context(VolumeSnafu)?.into();
+        let rows = dcm
+            .get(tags::ROWS)
+            .ok_or(LoadError::MissingProperty { name: "Rows" })?
+            .value()
+            .to_int::<i32>()
+            .context(InvalidPropertyValueSnafu { name: "Rows" })? as usize;
+        let columns = dcm
+            .get(tags::COLUMNS)
+            .ok_or(LoadError::MissingProperty { name: "Columns" })?
+            .value()
+            .to_int::<i32>()
+            .context(InvalidPropertyValueSnafu { name: "Columns" })? as usize;
+        let color_type = DicomColorType::try_from(dcm).context(ColorTypeSnafu)?;
+        Ok(Self {
+            num_frames,
+            height: rows,
+            width: columns,
+            channels: color_type.channels(),
+            channel_order: ChannelOrder::NHWC,
+        })
+    }
+}

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -11,6 +11,9 @@ pub use resolution::*;
 pub mod preprocessing;
 pub use preprocessing::*;
 
+pub mod dimensions;
+pub use dimensions::*;
+
 pub trait WriteTags {
     /// Write tags describing the transform to a TIFF encoder.
     fn write_tags<W, C, K, D>(&self, tiff: &mut ImageEncoder<W, C, K, D>) -> Result<(), TiffError>


### PR DESCRIPTION
Moves `Dimensions` to a separate module and enhances it to support creation from various types