### PR TITLE
Streamline Python bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ jobs:
                 paths:
                 - "~/.cargo"
                 - "./target"
+            - persist_to_workspace:
+                root: .
+                paths:
+                    - target/
 
     test_python:
         docker:
@@ -34,6 +38,16 @@ jobs:
             - restore_cache:
                 keys:
                   - v1-dependencies-{{ checksum "pdm.lock" }}
+            - attach_workspace:
+                at: .
+            - run:
+                name: Install Rust
+                command: |
+                    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+                    echo 'source "$HOME/.cargo/env"' >> $BASH_ENV
+            - run:
+                name: Version information
+                command: rustc --version; cargo --version; rustup --version
             - run:
                 name: Install dependencies
                 command: make init
@@ -49,5 +63,7 @@ jobs:
 workflows:
     build_and_test:
         jobs:
-            - test_python
             - build
+            - test_python:
+                requires:
+                    - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,3 +25,29 @@ jobs:
                 paths:
                 - "~/.cargo"
                 - "./target"
+
+    test_python:
+        docker:
+            - image: cimg/python:3.11-node
+        steps:
+            - checkout
+            - restore_cache:
+                keys:
+                  - v1-dependencies-{{ checksum "pdm.lock" }}
+            - run:
+                name: Install dependencies
+                command: make init
+            - save_cache:
+                paths:
+                  - ~/.cache/pip
+                  - ~/.cache/pdm
+                key: v1-dependencies-{{ checksum "pdm.lock" }}
+            - run:
+                name: Run tests
+                command: make test-python
+
+workflows:
+    build_and_test:
+        jobs:
+            - test_python
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
                 command: cargo build
             - run:
                 name: Test
-                command: cargo test --all-features
+                command: cargo test
             - save_cache:
                 key: project-cache
                 paths:
@@ -69,7 +69,10 @@ jobs:
                   - ~/.cache/pdm
                 key: v1-dependencies-{{ checksum "pdm.lock" }}
             - run:
-                name: Run tests
+                name: Run tests (Rust)
+                command: cargo test --features python
+            - run:
+                name: Run tests (Python)
                 command: make test-python
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,10 +69,7 @@ jobs:
                   - ~/.cache/pdm
                 key: v1-dependencies-{{ checksum "pdm.lock" }}
             - run:
-                name: Run tests (Rust)
-                command: cargo test --features python
-            - run:
-                name: Run tests (Python)
+                name: Run tests
                 command: make test-python
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,21 @@
 version: 2.1
 
 jobs:
+    quality:
+        docker:
+            - image: rust:latest
+        steps:
+            - checkout
+            - run:
+                name: Install dependencies
+                command: rustup component add rustfmt
+            - run:
+                name: Check formatting
+                command: cargo fmt -- --check
+            - run:
+                name: General check
+                command: cargo check --all-features
+
     build:
         docker:
             - image: rust:latest
@@ -12,14 +27,11 @@ jobs:
                 name: Install dependencies
                 command: rustup component add rustfmt
             - run:
-                name: Check formatting
-                command: cargo fmt -- --check
-            - run:
                 name: Stable Build
                 command: cargo build
             - run:
                 name: Test
-                command: cargo test
+                command: cargo test --all-features
             - save_cache:
                 key: project-cache
                 paths:
@@ -63,6 +75,7 @@ jobs:
 workflows:
     build_and_test:
         jobs:
+            - quality
             - build
             - test_python:
                 requires:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON=pdm run python
-PYTHON_DIRS=tests examples
+PYTHON_DIRS=tests examples dicom_preprocessing.pyi
 
 init:
 	which pdm || pip install --user pdm
@@ -20,8 +20,11 @@ style:
 	$(PYTHON) -m autopep8 -a $(PYTHON_DIRS)
 	$(PYTHON) -m black $(PYTHON_DIRS)
 
-test: 
-	cargo test
+test-python: 
 	$(PYTHON) -m pytest \
 		-rs \
 		./tests/
+
+test: 
+	cargo test
+	$(MAKE) test-python

--- a/dicom_preprocessing.pyi
+++ b/dicom_preprocessing.pyi
@@ -1,0 +1,115 @@
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import numpy.typing as npt
+
+def load_tiff_u8(path: str) -> npt.NDArray[np.uint8]:
+    """Load a TIFF file as an unsigned 8-bit numpy array.
+    If the TIFF is of a different bit depth, it will be scaled to 8-bit.
+
+    Args:
+        path: Path to the TIFF file
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        FileNotFoundError: If file cannot be found
+        IOError: If file cannot be opened
+        RuntimeError: If TIFF decoding fails
+    """
+    ...
+
+def load_tiff_u16(path: str) -> npt.NDArray[np.uint16]:
+    """Load a TIFF file as an unsigned 16-bit numpy array.
+    If the TIFF is of a different bit depth, it will be scaled to 16-bit.
+    Args:
+        path: Path to the TIFF file
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        FileNotFoundError: If file cannot be found
+        IOError: If file cannot be opened
+        RuntimeError: If TIFF decoding fails
+    """
+    ...
+
+def load_tiff_f32(path: str) -> npt.NDArray[np.float32]:
+    """Load a TIFF file as a 32-bit floating-point numpy array.
+    Inputs are scaled to the range :math:`[0, 1]` according to the source bit depth.
+
+    Args:
+        path: Path to the TIFF file
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        FileNotFoundError: If file cannot be found
+        IOError: If file cannot be opened
+        RuntimeError: If TIFF decoding fails
+    """
+    ...
+
+def find_dicom_files(path: Path, spinner: bool = False) -> List[Path]:
+    """Find all DICOM files in a directory recursively.
+
+    Args:
+        path: Directory path to search
+        spinner: Whether to show a progress spinner
+
+    Returns:
+        List of paths to DICOM files
+    """
+    ...
+
+def find_tiff_files(path: Path, spinner: bool = False) -> List[Path]:
+    """Find all TIFF files in a directory recursively.
+
+    Args:
+        path: Directory path to search
+        spinner: Whether to show a progress spinner
+
+    Returns:
+        List of paths to TIFF files
+    """
+    ...
+
+def read_dicom_paths(path: Path, bar: bool = False) -> List[Path]:
+    """Read paths to DICOM files from a text file containing one path per line.
+
+    Args:
+        path: Path to the text file
+        bar: Whether to show a progress bar
+
+    Returns:
+        List of paths to DICOM files
+    """
+    ...
+
+def read_tiff_paths(path: Path, bar: bool = False) -> List[Path]:
+    """Read paths to TIFF files from a text file containing one path per line.
+
+    Args:
+        path: Path to the text file
+        bar: Whether to show a progress bar
+
+    Returns:
+        List of paths to TIFF files
+    """
+    ...
+
+def inode_sort(paths: List[Path], bar: bool = False) -> List[Path]:
+    """Sort paths by inode number.
+
+    Args:
+        paths: List of paths to sort
+        bar: Whether to show a progress bar
+
+    Returns:
+        Sorted list of paths
+    """
+    ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,14 @@ requires = ["maturin>=1.0,<2.0", "pip", "cffi"]
 name = "dicom-preprocessing"
 description = "Preprocessing for DICOM images"
 requires-python = ">=3.10"
+dynamic = ["version"]
 
 [tool.maturin]
 bindings = "pyo3"  
 features = ["python"]
+version = { source = "cargo" }
+module-name = "dicom_preprocessing"
+package-data = ["*.pyi"]
 
 [tool.autoflake]
 remove-all-unused-imports = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,10 @@ fn run(args: Args) -> Result<(), Error> {
     } else {
         vec![args.source.clone()]
     };
-    let source = source.into_iter().sorted_by_inode().collect::<Vec<_>>();
+    let source = source
+        .into_iter()
+        .sorted_by_inode_with_progress()
+        .collect::<Vec<_>>();
 
     tracing::info!("Number of sources found: {}", source.len());
 

--- a/src/python/load.rs
+++ b/src/python/load.rs
@@ -5,23 +5,85 @@ use num::Zero;
 use numpy::Element;
 use numpy::{IntoPyArray, PyArray4};
 use pyo3::{
-    exceptions::{PyIOError, PyRuntimeError},
+    exceptions::{PyFileNotFoundError, PyIOError, PyNotADirectoryError, PyRuntimeError},
     pymodule,
-    types::PyModule,
-    Bound, PyResult, Python,
+    types::{PyAnyMethods, PyList, PyListMethods, PyModule},
+    Bound, FromPyObject, IntoPy, PyAny, PyResult, Python, ToPyObject,
 };
 use std::clone::Clone;
 use std::fs::File;
+use std::ops::Deref;
+use std::path::Path;
 use std::path::PathBuf;
 use tiff::decoder::Decoder;
 
+use pyo3::prelude::*;
+
+/// Wrapper to convert between Python Path and Rust PathBuf
+struct PyPath(PathBuf);
+
+impl FromPyObject<'_> for PyPath {
+    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let path = ob.extract::<PathBuf>()?;
+        Ok(PyPath(path))
+    }
+}
+
+impl ToPyObject for PyPath {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let pathlib = py
+            .import_bound("pathlib")
+            .expect("Failed to import pathlib");
+        let path_class = pathlib.getattr("Path").expect("Failed to get Path class");
+        path_class
+            .call1((self.0.to_string_lossy().into_owned(),))
+            .expect("Failed to create Path")
+            .into()
+    }
+}
+
+impl IntoPy<PyObject> for PyPath {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        self.to_object(py)
+    }
+}
+
+impl Deref for PyPath {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for PyPath {
+    fn as_ref(&self) -> &Path {
+        &self.0.as_ref()
+    }
+}
+
+impl From<PyPath> for PathBuf {
+    fn from(path: PyPath) -> Self {
+        path.0
+    }
+}
+
 #[pymodule]
 fn dicom_preprocessing<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()> {
-    fn load_tiff<'py, T>(py: Python<'py>, path: &str) -> PyResult<Bound<'py, PyArray4<T>>>
+    fn load_tiff<'py, T, P>(py: Python<'py>, path: P) -> PyResult<Bound<'py, PyArray4<T>>>
     where
         T: Clone + Zero + Element,
         Array4<T>: LoadFromTiff<T>,
+        P: AsRef<Path>,
     {
+        let path = path.as_ref();
+        if !path.is_file() {
+            return Err(PyFileNotFoundError::new_err(format!(
+                "File not found: {}",
+                path.display()
+            )));
+        }
+
         let file = File::open(path).map_err(|_| PyIOError::new_err("Failed to open file"))?;
         let mut decoder =
             Decoder::new(file).map_err(|_| PyRuntimeError::new_err("Failed to create decoder"))?;
@@ -32,66 +94,163 @@ fn dicom_preprocessing<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyRes
 
     #[pyfn(m)]
     #[pyo3(name = "load_tiff_u8")]
-    fn load_tiff_u8<'py>(py: Python<'py>, path: &str) -> PyResult<Bound<'py, PyArray4<u8>>> {
-        load_tiff::<u8>(py, path)
+    fn load_tiff_u8<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyArray4<u8>>> {
+        let path = path.extract::<PyPath>()?;
+        load_tiff::<u8, _>(py, path)
     }
 
     #[pyfn(m)]
     #[pyo3(name = "load_tiff_u16")]
-    fn load_tiff_u16<'py>(py: Python<'py>, path: &str) -> PyResult<Bound<'py, PyArray4<u16>>> {
-        load_tiff::<u16>(py, path)
+    fn load_tiff_u16<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyArray4<u16>>> {
+        let path = path.extract::<PyPath>()?;
+        load_tiff::<u16, _>(py, path)
     }
 
     #[pyfn(m)]
     #[pyo3(name = "load_tiff_f32")]
-    fn load_tiff_f32<'py>(py: Python<'py>, path: &str) -> PyResult<Bound<'py, PyArray4<f32>>> {
-        load_tiff::<f32>(py, path)
+    fn load_tiff_f32<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyArray4<f32>>> {
+        let path = path.extract::<PyPath>()?;
+        load_tiff::<f32, _>(py, path)
     }
 
     #[pyfn(m)]
-    #[pyo3(name = "inode_sort")]
-    fn inode_sort(paths: Vec<PathBuf>) -> PyResult<Vec<PathBuf>> {
-        let result = paths.into_iter().sorted_by_inode().collect::<Vec<_>>();
-        Ok(result)
+    #[pyo3(name = "inode_sort", signature = (paths, bar=false))]
+    fn inode_sort<'py>(
+        py: Python<'py>,
+        paths: Bound<'py, PyList>,
+        bar: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let mut iter = paths
+            .iter()
+            .map(|p| p.extract::<PyPath>())
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter();
+        let result: Vec<_> = match bar {
+            true => iter.sorted_by_inode_with_progress().collect(),
+            false => iter.sorted_by_inode().collect(),
+        };
+        Ok(result.into_py(py).into_bound(py))
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "is_dicom_file")]
+    fn is_dicom_file<'py>(path: &Bound<'py, PyAny>) -> PyResult<bool> {
+        let path = path.extract::<PyPath>()?;
+        path.is_dicom_file()
+            .map_err(|_| PyRuntimeError::new_err("Failed to check if file is DICOM"))
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "is_tiff_file")]
+    fn is_tiff_file<'py>(path: &Bound<'py, PyAny>) -> PyResult<bool> {
+        let path = path.extract::<PyPath>()?;
+        path.is_tiff_file()
+            .map_err(|_| PyRuntimeError::new_err("Failed to check if file is TIFF"))
     }
 
     #[pyfn(m)]
     #[pyo3(name = "find_dicom_files", signature = (path, spinner=false))]
-    fn find_dicom_files(path: PathBuf, spinner: bool) -> PyResult<Vec<PathBuf>> {
-        let result = match spinner {
-            true => path.find_dicoms_with_spinner()?.collect(),
-            false => path.find_dicoms()?.collect(),
+    fn find_dicom_files<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+        spinner: bool,
+    ) -> PyResult<Bound<'py, PyList>> {
+        let path = path.extract::<PyPath>()?;
+        if !path.is_dir() {
+            return Err(PyNotADirectoryError::new_err(format!(
+                "Not a directory: {}",
+                path.display()
+            )));
+        }
+        let result: Vec<PyPath> = match spinner {
+            true => path
+                .find_dicoms_with_spinner()?
+                .map(|p| PyPath(p))
+                .collect(),
+            false => path.find_dicoms()?.map(|p| PyPath(p)).collect(),
         };
+        let result = PyList::new_bound(py, result);
         Ok(result)
     }
 
     #[pyfn(m)]
     #[pyo3(name = "find_tiff_files", signature = (path, spinner=false))]
-    fn find_tiff_files(path: PathBuf, spinner: bool) -> PyResult<Vec<PathBuf>> {
-        let result = match spinner {
-            true => path.find_tiffs_with_spinner()?.collect(),
-            false => path.find_tiffs()?.collect(),
+    fn find_tiff_files<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+        spinner: bool,
+    ) -> PyResult<Bound<'py, PyList>> {
+        let path = path.extract::<PyPath>()?;
+        if !path.is_dir() {
+            return Err(PyNotADirectoryError::new_err(format!(
+                "Not a directory: {}",
+                path.display()
+            )));
+        }
+        let result: Vec<PyPath> = match spinner {
+            true => path.find_tiffs_with_spinner()?.map(|p| PyPath(p)).collect(),
+            false => path.find_tiffs()?.map(|p| PyPath(p)).collect(),
         };
+        let result = PyList::new_bound(py, result);
         Ok(result)
     }
 
     #[pyfn(m)]
     #[pyo3(name = "read_dicom_paths", signature = (path, bar=false))]
-    fn read_dicom_paths(path: PathBuf, bar: bool) -> PyResult<Vec<PathBuf>> {
-        let result = match bar {
-            true => path.read_dicom_paths_with_bar()?.collect(),
-            false => path.read_dicom_paths()?.collect(),
+    fn read_dicom_paths<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+        bar: bool,
+    ) -> PyResult<Bound<'py, PyList>> {
+        let path = path.extract::<PyPath>()?;
+        if !path.is_file() {
+            return Err(PyFileNotFoundError::new_err(format!(
+                "File not found: {}",
+                path.display()
+            )));
+        }
+        let result: Vec<PyPath> = match bar {
+            true => path
+                .read_dicom_paths_with_bar()?
+                .map(|p| PyPath(p))
+                .collect(),
+            false => path.read_dicom_paths()?.map(|p| PyPath(p)).collect(),
         };
+        let result = PyList::new_bound(py, result);
         Ok(result)
     }
 
     #[pyfn(m)]
     #[pyo3(name = "read_tiff_paths", signature = (path, bar=false))]
-    fn read_tiff_paths(path: PathBuf, bar: bool) -> PyResult<Vec<PathBuf>> {
-        let result = match bar {
-            true => path.read_tiff_paths_with_bar()?.collect(),
-            false => path.read_tiff_paths()?.collect(),
+    fn read_tiff_paths<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+        bar: bool,
+    ) -> PyResult<Bound<'py, PyList>> {
+        let path = path.extract::<PyPath>()?;
+        if !path.is_file() {
+            return Err(PyFileNotFoundError::new_err(format!(
+                "File not found: {}",
+                path.display()
+            )));
+        }
+        let result: Vec<PyPath> = match bar {
+            true => path
+                .read_tiff_paths_with_bar()?
+                .map(|p| PyPath(p))
+                .collect(),
+            false => path.read_tiff_paths()?.map(|p| PyPath(p)).collect(),
         };
+        let result = PyList::new_bound(py, result);
         Ok(result)
     }
 

--- a/src/python/load.rs
+++ b/src/python/load.rs
@@ -12,6 +12,7 @@ use pyo3::{
 };
 use std::clone::Clone;
 use std::fs::File;
+use std::io::BufReader;
 use std::ops::Deref;
 use std::path::Path;
 use std::path::PathBuf;
@@ -85,8 +86,9 @@ fn dicom_preprocessing<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyRes
         }
 
         let file = File::open(path).map_err(|_| PyIOError::new_err("Failed to open file"))?;
-        let mut decoder =
-            Decoder::new(file).map_err(|_| PyRuntimeError::new_err("Failed to create decoder"))?;
+        let reader = BufReader::new(file);
+        let mut decoder = Decoder::new(reader)
+            .map_err(|_| PyRuntimeError::new_err("Failed to create decoder"))?;
         let array = Array4::<T>::decode(&mut decoder)
             .map_err(|_| PyRuntimeError::new_err("Failed to decode TIFF"))?;
         Ok(array.into_pyarray_bound(py))

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,1 +1,2 @@
 pub mod load;
+pub mod path;

--- a/src/python/path.rs
+++ b/src/python/path.rs
@@ -1,0 +1,90 @@
+use pyo3::{types::PyAnyMethods, Bound, FromPyObject, IntoPy, PyAny, PyResult, Python, ToPyObject};
+use std::ops::Deref;
+use std::path::Path;
+use std::path::PathBuf;
+
+use pyo3::prelude::*;
+
+/// Wrapper to convert between Python Path and Rust PathBuf
+pub struct PyPath(PathBuf);
+
+impl PyPath {
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        PyPath(PathBuf::from(path.as_ref()))
+    }
+}
+
+impl FromPyObject<'_> for PyPath {
+    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let path = ob.extract::<PathBuf>()?;
+        Ok(PyPath(path))
+    }
+}
+
+impl ToPyObject for PyPath {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let pathlib = py
+            .import_bound("pathlib")
+            .expect("Failed to import pathlib");
+        let path_class = pathlib.getattr("Path").expect("Failed to get Path class");
+        path_class
+            .call1((self.0.to_string_lossy().into_owned(),))
+            .expect("Failed to create Path")
+            .into()
+    }
+}
+
+impl IntoPy<PyObject> for PyPath {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        self.to_object(py)
+    }
+}
+
+impl Deref for PyPath {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for PyPath {
+    fn as_ref(&self) -> &Path {
+        &self.0.as_ref()
+    }
+}
+
+impl From<PyPath> for PathBuf {
+    fn from(path: PyPath) -> Self {
+        path.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::Python;
+
+    #[test]
+    fn test_pypath_conversions() {
+        Python::with_gil(|py| {
+            // Create a Python Path object
+            let pathlib = py.import_bound("pathlib").unwrap();
+            let path_class = pathlib.getattr("Path").unwrap();
+            let test_path = path_class.call1(("test/path",)).unwrap();
+
+            // Convert Python Path to PyPath
+            let py_path: PyPath = test_path.extract().unwrap();
+            assert_eq!(py_path.0.to_str().unwrap(), "test/path");
+
+            // Convert PyPath back to Python Path
+            let py_obj = py_path.to_object(py);
+            let path_str = py_obj.call_method0(py, "__str__").unwrap();
+            assert_eq!(path_str.extract::<String>(py).unwrap(), "test/path");
+
+            // Test From<PyPath> for PathBuf
+            let path_buf: PathBuf = py_path.into();
+            assert_eq!(path_buf.to_str().unwrap(), "test/path");
+        });
+    }
+}

--- a/src/python/path.rs
+++ b/src/python/path.rs
@@ -59,32 +59,3 @@ impl From<PyPath> for PathBuf {
         path.0
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use pyo3::Python;
-
-    #[test]
-    fn test_pypath_conversions() {
-        Python::with_gil(|py| {
-            // Create a Python Path object
-            let pathlib = py.import_bound("pathlib").unwrap();
-            let path_class = pathlib.getattr("Path").unwrap();
-            let test_path = path_class.call1(("test/path",)).unwrap();
-
-            // Convert Python Path to PyPath
-            let py_path: PyPath = test_path.extract().unwrap();
-            assert_eq!(py_path.0.to_str().unwrap(), "test/path");
-
-            // Convert PyPath back to Python Path
-            let py_obj = py_path.to_object(py);
-            let path_str = py_obj.call_method0(py, "__str__").unwrap();
-            assert_eq!(path_str.extract::<String>(py).unwrap(), "test/path");
-
-            // Test From<PyPath> for PathBuf
-            let path_buf: PathBuf = py_path.into();
-            assert_eq!(path_buf.to_str().unwrap(), "test/path");
-        });
-    }
-}

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+import pytest
+from dicom_preprocessing import find_dicom_files, find_tiff_files, inode_sort, read_dicom_paths, read_tiff_paths
+
+
+@pytest.fixture(params=[Path, str])
+def path(request, tmp_path):
+    path = tmp_path / "test.txt"
+    if request.param == Path:
+        return path
+    elif request.param == str:
+        return str(path)
+    else:
+        raise ValueError(f"Invalid parameter: {request.param}")
+
+
+@pytest.fixture
+def dicom_dir(tmp_path):
+    # Create test DICOM files
+    (tmp_path / "test1.dcm").touch()
+    (tmp_path / "test2.DCM").touch()
+    (tmp_path / "test3.dicom").touch()
+    (tmp_path / "test4.DICOM").touch()
+    (tmp_path / "not_dicom.txt").touch()
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "test5.dcm").touch()
+    return tmp_path
+
+
+@pytest.fixture
+def tiff_dir(tmp_path):
+    # Create test TIFF files
+    (tmp_path / "test1.tif").touch()
+    (tmp_path / "test2.TIF").touch()
+    (tmp_path / "test3.tiff").touch()
+    (tmp_path / "test4.TIFF").touch()
+    (tmp_path / "not_tiff.txt").touch()
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "test5.tiff").touch()
+    return tmp_path
+
+
+@pytest.mark.parametrize("spinner", [True, False])
+def test_find_dicom_files(dicom_dir, spinner):
+    files = find_dicom_files(dicom_dir, spinner)
+    assert len(files) == 5
+    assert all(isinstance(p, Path) for p in files)
+    extensions = {Path(p).suffix.lower() for p in files}
+    assert extensions == {".dcm", ".dicom"}
+
+
+@pytest.mark.parametrize("spinner", [True, False])
+def test_find_tiff_files(tiff_dir, spinner):
+    files = find_tiff_files(tiff_dir, spinner)
+    assert len(files) == 5
+    assert all(isinstance(p, Path) for p in files)
+    extensions = {Path(p).suffix.lower() for p in files}
+    assert extensions == {".tif", ".tiff"}
+
+
+@pytest.mark.parametrize("bar", [True, False])
+def test_read_dicom_paths(path, bar):
+    # Create test file with paths
+    paths = [Path(path).parent / f"file{i}.dcm" for i in range(2)]
+    for p in paths:
+        p.touch()
+    with open(path, "w") as f:
+        f.write("\n".join([str(p) for p in paths]))
+    result = read_dicom_paths(path, bar)
+    assert len(result) == 2
+    assert all(isinstance(p, Path) for p in result)
+    assert result == paths
+
+
+@pytest.mark.parametrize("bar", [True, False])
+def test_read_tiff_paths(path, bar):
+    # Create test file with paths
+    paths = [Path(path).parent / f"file{i}.tiff" for i in range(2)]
+    for p in paths:
+        p.touch()
+    with open(path, "w") as f:
+        f.write("\n".join([str(p) for p in paths]))
+
+    result = read_tiff_paths(path, bar)
+    assert len(result) == 2
+    assert all(isinstance(p, Path) for p in result)
+    assert result == paths
+
+
+@pytest.mark.parametrize("bar", [True, False])
+def test_inode_sort(tmp_path, bar):
+    # Create test files
+    paths = []
+    for i in range(3):
+        p = tmp_path / f"file{i}.txt"
+        p.touch()
+        paths.append(p)
+
+    # Sort paths and verify they're ordered by inode
+    sorted_paths = inode_sort(paths, bar)
+    inodes = [Path(p).stat().st_ino for p in sorted_paths]
+    assert inodes == sorted(inodes)

--- a/tests/test_load_tiff.py
+++ b/tests/test_load_tiff.py
@@ -1,36 +1,47 @@
+from pathlib import Path
+
 import numpy as np
+import pytest
 from dicom_preprocessing import load_tiff_f32, load_tiff_u8, load_tiff_u16
 from PIL import Image
 
 
-def test_load_tiff_u8(tmp_path):
+@pytest.fixture(params=[Path, str])
+def path(request, tmp_path):
     path = tmp_path / "test.tiff"
+    if request.param == Path:
+        return path
+    elif request.param == str:
+        return str(path)
+    else:
+        raise ValueError(f"Invalid parameter: {request.param}")
+
+
+def test_load_tiff_u8(path):
     N, H, W, C = 3, 10, 10, 1
     array = np.random.randint(0, 255, size=(N, H, W, C), dtype=np.uint8)
     img = Image.fromarray(array[0, ..., 0])
     img.save(path, format="TIFF", save_all=True, append_images=[Image.fromarray(array[i, ..., 0]) for i in range(1, N)])
 
-    result = load_tiff_u8(str(path))
+    result = load_tiff_u8(path)
     assert np.array_equal(result, array)
 
 
-def test_load_tiff_u16(tmp_path):
-    path = tmp_path / "test.tiff"
+def test_load_tiff_u16(path):
     N, H, W, C = 3, 10, 10, 1
     array = np.random.randint(0, 65535, size=(N, H, W, C), dtype=np.uint16)
     img = Image.fromarray(array[0, ..., 0])
     img.save(path, format="TIFF", save_all=True, append_images=[Image.fromarray(array[i, ..., 0]) for i in range(1, N)])
 
-    result = load_tiff_u16(str(path))
+    result = load_tiff_u16(path)
     assert np.array_equal(result, array)
 
 
-def test_load_tiff_f32(tmp_path):
-    path = tmp_path / "test.tiff"
+def test_load_tiff_f32(path):
     N, H, W, C = 3, 10, 10, 1
     array = np.random.randint(0, 65535, size=(N, H, W, C), dtype=np.uint16)
     img = Image.fromarray(array[0, ..., 0])
     img.save(path, format="TIFF", save_all=True, append_images=[Image.fromarray(array[i, ..., 0]) for i in range(1, N)])
     array = array.astype(np.float32) / 65535
-    result = load_tiff_f32(str(path))
+    result = load_tiff_f32(path)
     assert np.array_equal(result, array)


### PR DESCRIPTION
Does the following:
* Add stub file for Python bindings
* Add call to support progress bar during inode sort and expose this to Python
* Add CI job for testing Python bindings
* Support inputs convertible to Path for relevant Python bindings, rather than requiring a specific type
* Produce Path outputs from relevant Python bindings
* Automatically set Python package version from Cargo.toml