### PR TITLE
Support cropping using connected components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 3
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
+
+[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +114,15 @@ name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arbitrary"
@@ -636,6 +661,7 @@ dependencies = [
  "dicom-test-files",
  "env_logger",
  "image",
+ "imageproc",
  "indicatif",
  "itertools 0.13.0",
  "log",
@@ -1015,8 +1041,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1297,6 +1325,24 @@ checksum = "e031e8e3d94711a9ccb5d6ea357439ef3dcbed361798bd4071dc4d9793fbe22f"
 dependencies = [
  "byteorder-lite",
  "quick-error",
+]
+
+[[package]]
+name = "imageproc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2393fb7808960751a52e8a154f67e7dd3f8a2ef9bd80d1553078a7b4e8ed3f0d"
+dependencies = [
+ "ab_glyph",
+ "approx",
+ "getrandom",
+ "image",
+ "itertools 0.12.1",
+ "nalgebra",
+ "num",
+ "rand",
+ "rand_distr",
+ "rayon",
 ]
 
 [[package]]
@@ -1633,6 +1679,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1770,21 @@ checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
 ]
 
 [[package]]
@@ -1862,6 +1929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1925,6 +1993,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
+dependencies = [
+ "ttf-parser",
+]
 
 [[package]]
 name = "owo-colors"
@@ -2186,6 +2263,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2531,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,6 +2621,19 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2868,6 +2977,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,6 +3181,16 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber = "0.3"
 num = "0.4"
 ndarray = "0.16"
 itertools = "0.13"
+imageproc = "0.25"
 pyo3 = { version = "0.22", features = ["extension-module"], optional = true }
 numpy = { version = "0.22", optional = true }
 

--- a/src/load.rs
+++ b/src/load.rs
@@ -159,6 +159,7 @@ mod tests {
             padding_direction: PaddingDirection::default(),
             crop_max: false,
             volume_handler: VolumeHandler::Keep(KeepVolume),
+            use_components: true,
         };
 
         let dicom_file = open_file(&dicom_test_files::path(dicom_file_path).unwrap()).unwrap();
@@ -286,6 +287,7 @@ mod tests {
             padding_direction: PaddingDirection::default(),
             crop_max: false,
             volume_handler: VolumeHandler::Keep(KeepVolume),
+            use_components: true,
         };
 
         let dicom_file_path = "pydicom/emri_small.dcm";

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,14 @@ struct Args {
     crop_max: bool,
 
     #[arg(
+        help = "Do not use connected components for the crop calculation",
+        long = "no-components",
+        short = 'n',
+        default_value_t = false
+    )]
+    no_components: bool,
+
+    #[arg(
         help = "Target size (width,height)",
         long = "size",
         short = 's',
@@ -340,6 +348,7 @@ fn run(args: Args) -> Result<(), Error> {
         padding_direction: args.padding_direction,
         crop_max: args.crop_max,
         volume_handler: args.volume_handler.into(),
+        use_components: !args.no_components,
     };
     let compressor = args.compressor;
 
@@ -444,6 +453,7 @@ mod tests {
             strict: true,
             compressor: SupportedCompressor::default(),
             crop_max: false,
+            no_components: false,
             volume_handler: DisplayVolumeHandler::default(),
         };
         run(args).unwrap();

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -20,6 +20,7 @@ pub struct Preprocessor {
     pub padding_direction: PaddingDirection,
     pub crop_max: bool,
     pub volume_handler: VolumeHandler,
+    pub use_components: bool,
 }
 
 impl Default for Preprocessor {
@@ -31,6 +32,7 @@ impl Default for Preprocessor {
             padding_direction: PaddingDirection::Zero,
             crop_max: true,
             volume_handler: VolumeHandler::default(),
+            use_components: true,
         }
     }
 }
@@ -41,6 +43,7 @@ impl Preprocessor {
             true => Some(Crop::new_from_images(
                 &images.iter().collect::<Vec<_>>(),
                 self.crop_max,
+                self.use_components,
             )),
             false => None,
         }
@@ -172,6 +175,7 @@ mod tests {
             padding_direction: PaddingDirection::default(),
             crop_max: false,
             volume_handler: VolumeHandler::Keep(KeepVolume),
+            use_components: true,
         },
         false
     )]
@@ -184,6 +188,7 @@ mod tests {
             padding_direction: PaddingDirection::default(),
             crop_max: false,
             volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+            use_components: true,
         },
         true
     )]
@@ -196,6 +201,7 @@ mod tests {
             padding_direction: PaddingDirection::default(),
             crop_max: false,
             volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+            use_components: true,
         },
         false
     )]
@@ -208,6 +214,7 @@ mod tests {
             padding_direction: PaddingDirection::default(),
             crop_max: false,
             volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+            use_components: true,
         },
         false
     )]
@@ -220,6 +227,7 @@ mod tests {
             padding_direction: PaddingDirection::default(),
             crop_max: false,
             volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+            use_components: true,
         },
         false
     )]
@@ -232,6 +240,7 @@ mod tests {
             padding_direction: PaddingDirection::default(),
             crop_max: false,
             volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+            use_components: true,
         },
         false
     )]

--- a/src/transform/crop.rs
+++ b/src/transform/crop.rs
@@ -1,4 +1,8 @@
-use image::{DynamicImage, GenericImageView, Pixel};
+use image::imageops::FilterType;
+use image::{DynamicImage, GenericImageView, Luma, Pixel};
+use imageproc::contrast::{threshold, ThresholdType};
+use imageproc::region_labelling::{connected_components, Connectivity};
+use itertools::Itertools;
 use std::io::{Read, Seek, Write};
 use tiff::decoder::Decoder;
 use tiff::encoder::colortype::ColorType;
@@ -14,6 +18,8 @@ use crate::transform::Transform;
 pub const DEFAULT_CROP_ORIGIN: u16 = 50719;
 pub const DEFAULT_CROP_SIZE: u16 = 50720;
 const DEFAULT_CHECK_MAX: bool = false;
+const DEFAULT_RESIZE_SIZE: u32 = 512;
+const NONZERO_THRESHOLD: u8 = 1;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Crop {
@@ -57,10 +63,95 @@ impl Crop {
         }
     }
 
-    pub fn new_from_images(images: &[&DynamicImage], check_max: bool) -> Self {
+    pub fn new_from_components(image: &DynamicImage, check_max: bool) -> Self {
+        // First generate a baseline crop
+        let crop = Crop::new(image, check_max);
+        let thumbnail = image.crop_imm(crop.left, crop.top, crop.width, crop.height);
+
+        // Resize the image to smaller size for fast computation of crop boundaries
+        let thumbnail = if thumbnail.width() > DEFAULT_RESIZE_SIZE
+            || thumbnail.height() > DEFAULT_RESIZE_SIZE
+        {
+            thumbnail.resize(
+                DEFAULT_RESIZE_SIZE,
+                DEFAULT_RESIZE_SIZE,
+                FilterType::Nearest,
+            )
+        } else {
+            thumbnail
+        };
+
+        // Threshold the image to find the background
+        // NOTE: This assumes that the background is black
+        let thumbnail = thumbnail.into_luma8();
+        let thumbnail = threshold(&thumbnail, NONZERO_THRESHOLD, ThresholdType::Binary);
+
+        // Compute connected components
+        let bg = Luma([0]);
+        let components = connected_components(&thumbnail, Connectivity::Four, bg);
+
+        // Find the largest connected component
+        let (max_component, _) = components
+            .iter()
+            .filter(|&&c| c > 0)
+            .counts()
+            .into_iter()
+            .max_by_key(|&(_, count)| count)
+            .unwrap_or((&0, 0));
+
+        // Compute crop bounds from the largest connected component
+        let (left, right, top, bottom) = components
+            .enumerate_pixels()
+            .filter(|&(_, _, c)| c[0] == *max_component)
+            .fold(
+                (thumbnail.width() - 1, 0, thumbnail.height() - 1, 0),
+                |(min_x, max_x, min_y, max_y), (x, y, _)| {
+                    (min_x.min(x), max_x.max(x), min_y.min(y), max_y.max(y))
+                },
+            );
+
+        // Determine scale factor between resized and original cropped image
+        let orig_width = crop.width;
+        let orig_height = crop.height;
+        let scale_w = orig_width as f32 / thumbnail.width() as f32;
+        let scale_h = orig_height as f32 / thumbnail.height() as f32;
+
+        // Scale crop coordinates to the original image size
+        let left = (left as f32 * scale_w).round() as u32;
+        let top = (top as f32 * scale_h).round() as u32;
+        let right = (right as f32 * scale_w).round() as u32;
+        let bottom = (bottom as f32 * scale_h).round() as u32;
+
+        // Offset crop coordinates to the original image
+        let left = left + crop.left;
+        let top = top + crop.top;
+        let right = right + crop.left;
+        let bottom = bottom + crop.top;
+
+        let width = right - left + 1;
+        let height = bottom - top + 1;
+        Crop {
+            left,
+            top,
+            width,
+            height,
+        }
+    }
+
+    pub fn new_from_images(
+        images: &[&DynamicImage],
+        check_max: bool,
+        use_components: bool,
+    ) -> Self {
         images
             .iter()
-            .map(|&image| Crop::new(image, check_max))
+            .map(|&image| {
+                if use_components {
+                    Crop::new_from_components(image, check_max)
+                } else {
+                    Crop::new(image, check_max)
+                }
+            })
             .reduce(|a, b| a.union(&b))
             .unwrap()
     }
@@ -138,7 +229,7 @@ fn is_uncroppable_pixel(x: u32, y: u32, image: &DynamicImage, check_max: bool) -
 
 impl From<&DynamicImage> for Crop {
     fn from(image: &DynamicImage) -> Self {
-        Crop::new(image, DEFAULT_CHECK_MAX)
+        Crop::new_from_components(image, DEFAULT_CHECK_MAX)
     }
 }
 
@@ -300,6 +391,73 @@ mod tests {
         let dynamic_image = DynamicImage::ImageRgba8(img);
 
         let crop = Crop::new(&dynamic_image, crop_max);
+        let expected_crop = Crop {
+            left: expected_crop.0,
+            top: expected_crop.1,
+            width: expected_crop.2,
+            height: expected_crop.3,
+        };
+        assert_eq!(crop, expected_crop);
+    }
+
+    #[rstest]
+    #[case(
+        vec![
+            vec![0, 0, 0, 0],
+            vec![0, 1, 1, 0],
+            vec![0, 1, 1, 0],
+            vec![0, 0, 0, 0],
+        ],
+        false,
+        (1, 1, 2, 2)
+    )]
+    #[case(
+        vec![
+            vec![0, 0, 0, 0],
+            vec![0, 0, 0, 0],
+            vec![0, 0, 0, 0],
+            vec![0, 0, 0, 0],
+        ],
+        false,
+        (0, 0, 4, 4)
+    )]
+    #[case(
+        vec![
+            vec![1, 1, 1, 1],
+            vec![1, 1, 1, 1],
+            vec![1, 1, 1, 1],
+            vec![1, 1, 1, 1],
+        ],
+        false,
+        (0, 0, 4, 4)
+    )]
+    #[case(
+        vec![
+            vec![255, 0, 0, 0],
+            vec![0, 1, 1, 0],
+            vec![0, 1, 1, 0],
+            vec![0, 0, 0, 255],
+        ],
+        true,
+        (1, 1, 2, 2)
+    )]
+    fn test_find_non_zero_boundaries_components(
+        #[case] pixels: Vec<Vec<u8>>,
+        #[case] check_max: bool,
+        #[case] expected_crop: (u32, u32, u32, u32),
+    ) {
+        // Create a new image from the pixel data
+        let width = pixels[0].len() as u32;
+        let height = pixels.len() as u32;
+        let mut img = RgbaImage::new(width, height);
+        for (y, row) in pixels.iter().enumerate() {
+            for (x, &value) in row.iter().enumerate() {
+                img.put_pixel(x as u32, y as u32, image::Rgba([value, value, value, 255]));
+            }
+        }
+        let dynamic_image = DynamicImage::ImageRgba8(img);
+
+        let crop = Crop::new_from_components(&dynamic_image, check_max);
         let expected_crop = Crop {
             left: expected_crop.0,
             top: expected_crop.1,


### PR DESCRIPTION
Using crops based on connected components can mitigate the impact of watermarks that are not all min or all max value. This implementation requires background pixels to be 0, and crops to the largest connected component of nonzero pixels.

|Without Components|With Components|
|--|--|
|![test2_no_component](https://github.com/user-attachments/assets/ee3e5176-7c88-432b-a5d0-a2a05a4fdd4e)|![test2_component](https://github.com/user-attachments/assets/69d8a766-3b1b-434c-8a88-36fa07dd871f)|
