### PR TITLE
Add option to disable padding

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -160,6 +160,7 @@ mod tests {
             crop_max: false,
             volume_handler: VolumeHandler::Keep(KeepVolume),
             use_components: true,
+            use_padding: true,
         };
 
         let dicom_file = open_file(&dicom_test_files::path(dicom_file_path).unwrap()).unwrap();
@@ -288,6 +289,7 @@ mod tests {
             crop_max: false,
             volume_handler: VolumeHandler::Keep(KeepVolume),
             use_components: true,
+            use_padding: true,
         };
 
         let dicom_file_path = "pydicom/emri_small.dcm";

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,9 @@ struct Args {
     )]
     padding_direction: PaddingDirection,
 
+    #[arg(help = "Disable padding", long = "no-padding", default_value_t = false)]
+    no_padding: bool,
+
     #[arg(
         help = "Compression type",
         long = "compressor",
@@ -349,6 +352,7 @@ fn run(args: Args) -> Result<(), Error> {
         crop_max: args.crop_max,
         volume_handler: args.volume_handler.into(),
         use_components: !args.no_components,
+        use_padding: !args.no_padding,
     };
     let compressor = args.compressor;
 
@@ -455,6 +459,7 @@ mod tests {
             crop_max: false,
             no_components: false,
             volume_handler: DisplayVolumeHandler::default(),
+            no_padding: false,
         };
         run(args).unwrap();
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -164,7 +164,7 @@ mod tests {
     use dicom::object::open_file;
 
     use crate::volume::{CentralSlice, KeepVolume, VolumeHandler};
-    use image::GenericImageView;
+    use image::{GenericImageView, RgbaImage};
     use rstest::rstest;
 
     #[rstest]


### PR DESCRIPTION
Avoiding storage of padded images will reduce the both the stored data volume and the IO bandwidth required to load images. In the future we can add features to the Python binding so that the loaded image can be padded to the size it would have been under padding