### PR TITLE
Add Python bindings for DICOM preprocessing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,10 @@ pyo3 = { version = "0.22", features = ["extension-module"], optional = true }
 numpy = { version = "0.22", optional = true }
 arrow = "50.0"
 parquet = "50.0"
+tempfile = { version = "3.10", optional = true }
 
 [features]
-python = ["pyo3", "numpy"]
+python = ["pyo3", "numpy", "tempfile"]
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/README.md
+++ b/README.md
@@ -127,3 +127,15 @@ Example usage:
 ```
 dicom-manifest /path/to/preprocessed/dataset /path/to/manifest.csv
 ```
+
+### Python Bindings
+
+Python bindings are provided via the `pyo3` crate. The following features are supported:
+ - Loading preprocessed TIFFs into Numpy arrays
+ - Iterating, sorting, and discovering DICOM or TIFF files from various sources
+ - Direct preprocessing of a DICOM file or buffer into a Numpy array
+
+Direct preprocessing of a DICOM file or buffer into a Numpy array is achieved using a temporary TIFF file.
+This temporary file is spooled, having an in-memory capacity of 64MB with additional space allocated on disk as needed.
+This spool size was chosen to accommodate most preprocessed 2D images without being overly burdensome.
+In the future we will support a direct conversion, avoiding the need for an intermediate TIFF file.

--- a/dicom_preprocessing.pyi
+++ b/dicom_preprocessing.pyi
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Tuple, Union
-from io import BytesIO
 
 import numpy as np
 import numpy.typing as npt
@@ -22,6 +21,7 @@ class Preprocessor:
     Raises:
         ValueError: If invalid filter type, padding direction or volume handler specified
     """
+
     def __init__(
         self,
         crop: bool = True,
@@ -283,4 +283,3 @@ def load_tiff_f32_batched(paths: List[Path], batch_size: int) -> Iterator[List[n
         A batch of TIFF files as 32-bit floating-point numpy arrays
     """
     ...
-

--- a/dicom_preprocessing.pyi
+++ b/dicom_preprocessing.pyi
@@ -1,11 +1,41 @@
 from pathlib import Path
-from typing import Dict, Iterator, List, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 from io import BytesIO
 
 import numpy as np
 import numpy.typing as npt
 
-def load_tiff_u8(path: str) -> npt.NDArray[np.uint8]:
+class Preprocessor:
+    """Configuration for DICOM preprocessing.
+
+    Args:
+        crop: Whether to crop zero-valued borders
+        size: Target size as (width, height) tuple
+        filter: Interpolation filter for resizing. One of: nearest, triangle, catmull, gaussian, lanczos3
+        padding_direction: Direction to pad when aspect ratio doesn't match target. One of: zero, center, edge
+        crop_max: Whether to crop to maximum possible size
+        volume_handler: How to handle multi-frame volumes. One of: keep, central
+        use_components: Whether to use color components for cropping
+        use_padding: Whether to pad to target size
+        border_frac: Optional fraction of border to keep when cropping
+
+    Raises:
+        ValueError: If invalid filter type, padding direction or volume handler specified
+    """
+    def __init__(
+        self,
+        crop: bool = True,
+        size: Optional[Tuple[int, int]] = None,
+        filter: str = "triangle",
+        padding_direction: str = "zero",
+        crop_max: bool = True,
+        volume_handler: str = "keep",
+        use_components: bool = True,
+        use_padding: bool = True,
+        border_frac: Optional[float] = None,
+    ) -> None: ...
+
+def load_tiff_u8(path: Union[str, Path]) -> npt.NDArray[np.uint8]:
     """Load a TIFF file as an unsigned 8-bit numpy array.
     If the TIFF is of a different bit depth, it will be scaled to 8-bit.
 
@@ -22,7 +52,7 @@ def load_tiff_u8(path: str) -> npt.NDArray[np.uint8]:
     """
     ...
 
-def load_tiff_u16(path: str) -> npt.NDArray[np.uint16]:
+def load_tiff_u16(path: Union[str, Path]) -> npt.NDArray[np.uint16]:
     """Load a TIFF file as an unsigned 16-bit numpy array.
     If the TIFF is of a different bit depth, it will be scaled to 16-bit.
     Args:
@@ -38,7 +68,7 @@ def load_tiff_u16(path: str) -> npt.NDArray[np.uint16]:
     """
     ...
 
-def load_tiff_f32(path: str) -> npt.NDArray[np.float32]:
+def load_tiff_f32(path: Union[str, Path]) -> npt.NDArray[np.float32]:
     """Load a TIFF file as a 32-bit floating-point numpy array.
     Inputs are scaled to the range :math:`[0, 1]` according to the source bit depth.
 
@@ -52,6 +82,104 @@ def load_tiff_f32(path: str) -> npt.NDArray[np.float32]:
         FileNotFoundError: If file cannot be found
         IOError: If file cannot be opened
         RuntimeError: If TIFF decoding fails
+    """
+    ...
+
+def preprocess_u8(path: Union[str, Path], preprocessor: Optional[Preprocessor] = None) -> npt.NDArray[np.uint8]:
+    """Preprocess a DICOM file and return as 8-bit unsigned integer array.
+
+    Args:
+        path: Path to DICOM file
+        preprocessor: Optional preprocessing configuration
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        FileNotFoundError: If file cannot be found
+        RuntimeError: If preprocessing fails
+    """
+    ...
+
+def preprocess_u16(path: Union[str, Path], preprocessor: Optional[Preprocessor] = None) -> npt.NDArray[np.uint16]:
+    """Preprocess a DICOM file and return as 16-bit unsigned integer array.
+
+    Args:
+        path: Path to DICOM file
+        preprocessor: Optional preprocessing configuration
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        FileNotFoundError: If file cannot be found
+        RuntimeError: If preprocessing fails
+    """
+    ...
+
+def preprocess_f32(path: Union[str, Path], preprocessor: Optional[Preprocessor] = None) -> npt.NDArray[np.float32]:
+    """Preprocess a DICOM file and return as 32-bit floating point array.
+    Values are scaled to the range :math:`[0, 1]`.
+
+    Args:
+        path: Path to DICOM file
+        preprocessor: Optional preprocessing configuration
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        FileNotFoundError: If file cannot be found
+        RuntimeError: If preprocessing fails
+    """
+    ...
+
+def preprocess_stream_u8(buffer: bytes, preprocessor: Optional[Preprocessor] = None) -> npt.NDArray[np.uint8]:
+    """Preprocess a DICOM file from a bytes buffer and return as 8-bit unsigned integer array.
+
+    Args:
+        buffer: DICOM file contents as bytes
+        preprocessor: Optional preprocessing configuration
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        RuntimeError: If preprocessing fails
+        ValueError: If buffer is not contiguous
+    """
+    ...
+
+def preprocess_stream_u16(buffer: bytes, preprocessor: Optional[Preprocessor] = None) -> npt.NDArray[np.uint16]:
+    """Preprocess a DICOM file from a bytes buffer and return as 16-bit unsigned integer array.
+
+    Args:
+        buffer: DICOM file contents as bytes
+        preprocessor: Optional preprocessing configuration
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        RuntimeError: If preprocessing fails
+        ValueError: If buffer is not contiguous
+    """
+    ...
+
+def preprocess_stream_f32(buffer: bytes, preprocessor: Optional[Preprocessor] = None) -> npt.NDArray[np.float32]:
+    """Preprocess a DICOM file from a bytes buffer and return as 32-bit floating point array.
+    Values are scaled to the range :math:`[0, 1]`.
+
+    Args:
+        buffer: DICOM file contents as bytes
+        preprocessor: Optional preprocessing configuration
+
+    Returns:
+        4D array with shape :math:`(N, H, W, C)`
+
+    Raises:
+        RuntimeError: If preprocessing fails
+        ValueError: If buffer is not contiguous
     """
     ...
 
@@ -156,36 +284,3 @@ def load_tiff_f32_batched(paths: List[Path], batch_size: int) -> Iterator[List[n
     """
     ...
 
-
-class PreprocessingMetadata:
-    ...
-    
-
-
-def preprocess(
-    target: str | Path | BytesIO,
-    crop: bool = True,
-    size: Tuple[int, int] | None = None,
-    filter: str = "triangle",
-    padding_direction: str = "zero",
-    crop_max: bool = True,
-    volume_handler: str = "keep",
-    use_components: bool = True,
-    use_padding: bool = True,
-    border_frac: float | None = None,
-) -> Tuple[npt.NDArray[np.float32], :
-    """Preprocess a DICOM file or byte stream of a DICOM file.
-
-    Args:
-        target: Path to a DICOM file, a byte stream of a DICOM file, or a directory containing DICOM files
-        crop: Whether to crop the image
-        size: Tuple of width and height to resize the image to
-        filter: Filter to use for resizing the image
-        padding_direction: Direction to pad the image
-        crop_max: Whether to crop the image to the maximum possible size
-        volume_handler: Handler to use for volume handling
-
-    Returns:
-        Preprocess
-    """
-    ...

--- a/dicom_preprocessing.pyi
+++ b/dicom_preprocessing.pyi
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Dict, Iterator, List
+from typing import Dict, Iterator, List, Tuple
+from io import BytesIO
 
 import numpy as np
 import numpy.typing as npt
@@ -152,5 +153,39 @@ def load_tiff_f32_batched(paths: List[Path], batch_size: int) -> Iterator[List[n
 
     Yields:
         A batch of TIFF files as 32-bit floating-point numpy arrays
+    """
+    ...
+
+
+class PreprocessingMetadata:
+    ...
+    
+
+
+def preprocess(
+    target: str | Path | BytesIO,
+    crop: bool = True,
+    size: Tuple[int, int] | None = None,
+    filter: str = "triangle",
+    padding_direction: str = "zero",
+    crop_max: bool = True,
+    volume_handler: str = "keep",
+    use_components: bool = True,
+    use_padding: bool = True,
+    border_frac: float | None = None,
+) -> Tuple[npt.NDArray[np.float32], :
+    """Preprocess a DICOM file or byte stream of a DICOM file.
+
+    Args:
+        target: Path to a DICOM file, a byte stream of a DICOM file, or a directory containing DICOM files
+        crop: Whether to crop the image
+        size: Tuple of width and height to resize the image to
+        filter: Filter to use for resizing the image
+        padding_direction: Direction to pad the image
+        crop_max: Whether to crop the image to the maximum possible size
+        volume_handler: Handler to use for volume handling
+
+    Returns:
+        Preprocess
     """
     ...

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "quality", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5f4237b9cbff803c29ce209d93eaabb8899e36433f2d6b6051681cbba483090f"
+content_hash = "sha256:4c2c1b21f76e23c02f05d518d734ffa587772700228b33d150d3da0111ceb52e"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -117,7 +117,7 @@ files = [
 
 [[package]]
 name = "flake8"
-version = "7.1.1"
+version = "7.1.2"
 requires_python = ">=3.8.1"
 summary = "the modular source code checker: pep8 pyflakes and co"
 groups = ["quality"]
@@ -127,8 +127,8 @@ dependencies = [
     "pyflakes<3.3.0,>=3.2.0",
 ]
 files = [
-    {file = "flake8-7.1.1-py2.py3-none-any.whl", hash = "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213"},
-    {file = "flake8-7.1.1.tar.gz", hash = "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38"},
+    {file = "flake8-7.1.2-py2.py3-none-any.whl", hash = "sha256:1cbc62e65536f65e6d754dfe6f1bada7f5cf392d6f5db3c2b85892466c3e7c1a"},
+    {file = "flake8-7.1.2.tar.gz", hash = "sha256:c586ffd0b41540951ae41af572e6790dbd49fc12b3aa2541685d253d9bd504bd"},
 ]
 
 [[package]]
@@ -144,13 +144,13 @@ files = [
 
 [[package]]
 name = "isort"
-version = "6.0.0"
+version = "6.0.1"
 requires_python = ">=3.9.0"
 summary = "A Python utility / library to sort Python imports."
 groups = ["quality"]
 files = [
-    {file = "isort-6.0.0-py3-none-any.whl", hash = "sha256:567954102bb47bb12e0fae62606570faacddd441e45683968c8d1734fb1af892"},
-    {file = "isort-6.0.0.tar.gz", hash = "sha256:75d9d8a1438a9432a7d7b54f2d3b45cad9a4a0fdba43617d9873379704a8bdf1"},
+    {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
+    {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
 ]
 
 [[package]]
@@ -177,66 +177,66 @@ files = [
 
 [[package]]
 name = "numpy"
-version = "2.2.2"
+version = "2.2.3"
 requires_python = ">=3.10"
 summary = "Fundamental package for array computing in Python"
 groups = ["test"]
 files = [
-    {file = "numpy-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7079129b64cb78bdc8d611d1fd7e8002c0a2565da6a47c4df8062349fee90e3e"},
-    {file = "numpy-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ec6c689c61df613b783aeb21f945c4cbe6c51c28cb70aae8430577ab39f163e"},
-    {file = "numpy-2.2.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:40c7ff5da22cd391944a28c6a9c638a5eef77fcf71d6e3a79e1d9d9e82752715"},
-    {file = "numpy-2.2.2-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:995f9e8181723852ca458e22de5d9b7d3ba4da3f11cc1cb113f093b271d7965a"},
-    {file = "numpy-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b78ea78450fd96a498f50ee096f69c75379af5138f7881a51355ab0e11286c97"},
-    {file = "numpy-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fbe72d347fbc59f94124125e73fc4976a06927ebc503ec5afbfb35f193cd957"},
-    {file = "numpy-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8e6da5cffbbe571f93588f562ed130ea63ee206d12851b60819512dd3e1ba50d"},
-    {file = "numpy-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:09d6a2032faf25e8d0cadde7fd6145118ac55d2740132c1d845f98721b5ebcfd"},
-    {file = "numpy-2.2.2-cp310-cp310-win32.whl", hash = "sha256:159ff6ee4c4a36a23fe01b7c3d07bd8c14cc433d9720f977fcd52c13c0098160"},
-    {file = "numpy-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:64bd6e1762cd7f0986a740fee4dff927b9ec2c5e4d9a28d056eb17d332158014"},
-    {file = "numpy-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:642199e98af1bd2b6aeb8ecf726972d238c9877b0f6e8221ee5ab945ec8a2189"},
-    {file = "numpy-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d9fc9d812c81e6168b6d405bf00b8d6739a7f72ef22a9214c4241e0dc70b323"},
-    {file = "numpy-2.2.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:c7d1fd447e33ee20c1f33f2c8e6634211124a9aabde3c617687d8b739aa69eac"},
-    {file = "numpy-2.2.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:451e854cfae0febe723077bd0cf0a4302a5d84ff25f0bfece8f29206c7bed02e"},
-    {file = "numpy-2.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd249bc894af67cbd8bad2c22e7cbcd46cf87ddfca1f1289d1e7e54868cc785c"},
-    {file = "numpy-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02935e2c3c0c6cbe9c7955a8efa8908dd4221d7755644c59d1bba28b94fd334f"},
-    {file = "numpy-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a972cec723e0563aa0823ee2ab1df0cb196ed0778f173b381c871a03719d4826"},
-    {file = "numpy-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d6d6a0910c3b4368d89dde073e630882cdb266755565155bc33520283b2d9df8"},
-    {file = "numpy-2.2.2-cp311-cp311-win32.whl", hash = "sha256:860fd59990c37c3ef913c3ae390b3929d005243acca1a86facb0773e2d8d9e50"},
-    {file = "numpy-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:da1eeb460ecce8d5b8608826595c777728cdf28ce7b5a5a8c8ac8d949beadcf2"},
-    {file = "numpy-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ac9bea18d6d58a995fac1b2cb4488e17eceeac413af014b1dd26170b766d8467"},
-    {file = "numpy-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23ae9f0c2d889b7b2d88a3791f6c09e2ef827c2446f1c4a3e3e76328ee4afd9a"},
-    {file = "numpy-2.2.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3074634ea4d6df66be04f6728ee1d173cfded75d002c75fac79503a880bf3825"},
-    {file = "numpy-2.2.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:8ec0636d3f7d68520afc6ac2dc4b8341ddb725039de042faf0e311599f54eb37"},
-    {file = "numpy-2.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ffbb1acd69fdf8e89dd60ef6182ca90a743620957afb7066385a7bbe88dc748"},
-    {file = "numpy-2.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0349b025e15ea9d05c3d63f9657707a4e1d471128a3b1d876c095f328f8ff7f0"},
-    {file = "numpy-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:463247edcee4a5537841d5350bc87fe8e92d7dd0e8c71c995d2c6eecb8208278"},
-    {file = "numpy-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9dd47ff0cb2a656ad69c38da850df3454da88ee9a6fde0ba79acceee0e79daba"},
-    {file = "numpy-2.2.2-cp312-cp312-win32.whl", hash = "sha256:4525b88c11906d5ab1b0ec1f290996c0020dd318af8b49acaa46f198b1ffc283"},
-    {file = "numpy-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:5acea83b801e98541619af398cc0109ff48016955cc0818f478ee9ef1c5c3dcb"},
-    {file = "numpy-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b208cfd4f5fe34e1535c08983a1a6803fdbc7a1e86cf13dd0c61de0b51a0aadc"},
-    {file = "numpy-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d0bbe7dd86dca64854f4b6ce2ea5c60b51e36dfd597300057cf473d3615f2369"},
-    {file = "numpy-2.2.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:22ea3bb552ade325530e72a0c557cdf2dea8914d3a5e1fecf58fa5dbcc6f43cd"},
-    {file = "numpy-2.2.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:128c41c085cab8a85dc29e66ed88c05613dccf6bc28b3866cd16050a2f5448be"},
-    {file = "numpy-2.2.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:250c16b277e3b809ac20d1f590716597481061b514223c7badb7a0f9993c7f84"},
-    {file = "numpy-2.2.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0c8854b09bc4de7b041148d8550d3bd712b5c21ff6a8ed308085f190235d7ff"},
-    {file = "numpy-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b6fb9c32a91ec32a689ec6410def76443e3c750e7cfc3fb2206b985ffb2b85f0"},
-    {file = "numpy-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:57b4012e04cc12b78590a334907e01b3a85efb2107df2b8733ff1ed05fce71de"},
-    {file = "numpy-2.2.2-cp313-cp313-win32.whl", hash = "sha256:4dbd80e453bd34bd003b16bd802fac70ad76bd463f81f0c518d1245b1c55e3d9"},
-    {file = "numpy-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:5a8c863ceacae696aff37d1fd636121f1a512117652e5dfb86031c8d84836369"},
-    {file = "numpy-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b3482cb7b3325faa5f6bc179649406058253d91ceda359c104dac0ad320e1391"},
-    {file = "numpy-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9491100aba630910489c1d0158034e1c9a6546f0b1340f716d522dc103788e39"},
-    {file = "numpy-2.2.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:41184c416143defa34cc8eb9d070b0a5ba4f13a0fa96a709e20584638254b317"},
-    {file = "numpy-2.2.2-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7dca87ca328f5ea7dafc907c5ec100d187911f94825f8700caac0b3f4c384b49"},
-    {file = "numpy-2.2.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bc61b307655d1a7f9f4b043628b9f2b721e80839914ede634e3d485913e1fb2"},
-    {file = "numpy-2.2.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fad446ad0bc886855ddf5909cbf8cb5d0faa637aaa6277fb4b19ade134ab3c7"},
-    {file = "numpy-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:149d1113ac15005652e8d0d3f6fd599360e1a708a4f98e43c9c77834a28238cb"},
-    {file = "numpy-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:106397dbbb1896f99e044efc90360d098b3335060375c26aa89c0d8a97c5f648"},
-    {file = "numpy-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:0eec19f8af947a61e968d5429f0bd92fec46d92b0008d0a6685b40d6adf8a4f4"},
-    {file = "numpy-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:97b974d3ba0fb4612b77ed35d7627490e8e3dff56ab41454d9e8b23448940576"},
-    {file = "numpy-2.2.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b0531f0b0e07643eb089df4c509d30d72c9ef40defa53e41363eca8a8cc61495"},
-    {file = "numpy-2.2.2-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:e9e82dcb3f2ebbc8cb5ce1102d5f1c5ed236bf8a11730fb45ba82e2841ec21df"},
-    {file = "numpy-2.2.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0d4142eb40ca6f94539e4db929410f2a46052a0fe7a2c1c59f6179c39938d2a"},
-    {file = "numpy-2.2.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:356ca982c188acbfa6af0d694284d8cf20e95b1c3d0aefa8929376fea9146f60"},
-    {file = "numpy-2.2.2.tar.gz", hash = "sha256:ed6906f61834d687738d25988ae117683705636936cc605be0bb208b23df4d8f"},
+    {file = "numpy-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cbc6472e01952d3d1b2772b720428f8b90e2deea8344e854df22b0618e9cce71"},
+    {file = "numpy-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdfe0c22692a30cd830c0755746473ae66c4a8f2e7bd508b35fb3b6a0813d787"},
+    {file = "numpy-2.2.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:e37242f5324ffd9f7ba5acf96d774f9276aa62a966c0bad8dae692deebec7716"},
+    {file = "numpy-2.2.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:95172a21038c9b423e68be78fd0be6e1b97674cde269b76fe269a5dfa6fadf0b"},
+    {file = "numpy-2.2.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5b47c440210c5d1d67e1cf434124e0b5c395eee1f5806fdd89b553ed1acd0a3"},
+    {file = "numpy-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0391ea3622f5c51a2e29708877d56e3d276827ac5447d7f45e9bc4ade8923c52"},
+    {file = "numpy-2.2.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f6b3dfc7661f8842babd8ea07e9897fe3d9b69a1d7e5fbb743e4160f9387833b"},
+    {file = "numpy-2.2.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1ad78ce7f18ce4e7df1b2ea4019b5817a2f6a8a16e34ff2775f646adce0a5027"},
+    {file = "numpy-2.2.3-cp310-cp310-win32.whl", hash = "sha256:5ebeb7ef54a7be11044c33a17b2624abe4307a75893c001a4800857956b41094"},
+    {file = "numpy-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:596140185c7fa113563c67c2e894eabe0daea18cf8e33851738c19f70ce86aeb"},
+    {file = "numpy-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:16372619ee728ed67a2a606a614f56d3eabc5b86f8b615c79d01957062826ca8"},
+    {file = "numpy-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5521a06a3148686d9269c53b09f7d399a5725c47bbb5b35747e1cb76326b714b"},
+    {file = "numpy-2.2.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:7c8dde0ca2f77828815fd1aedfdf52e59071a5bae30dac3b4da2a335c672149a"},
+    {file = "numpy-2.2.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:77974aba6c1bc26e3c205c2214f0d5b4305bdc719268b93e768ddb17e3fdd636"},
+    {file = "numpy-2.2.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d42f9c36d06440e34226e8bd65ff065ca0963aeecada587b937011efa02cdc9d"},
+    {file = "numpy-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2712c5179f40af9ddc8f6727f2bd910ea0eb50206daea75f58ddd9fa3f715bb"},
+    {file = "numpy-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c8b0451d2ec95010d1db8ca733afc41f659f425b7f608af569711097fd6014e2"},
+    {file = "numpy-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9b4a8148c57ecac25a16b0e11798cbe88edf5237b0df99973687dd866f05e1b"},
+    {file = "numpy-2.2.3-cp311-cp311-win32.whl", hash = "sha256:1f45315b2dc58d8a3e7754fe4e38b6fce132dab284a92851e41b2b344f6441c5"},
+    {file = "numpy-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f48ba6f6c13e5e49f3d3efb1b51c8193215c42ac82610a04624906a9270be6f"},
+    {file = "numpy-2.2.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12c045f43b1d2915eca6b880a7f4a256f59d62df4f044788c8ba67709412128d"},
+    {file = "numpy-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:87eed225fd415bbae787f93a457af7f5990b92a334e346f72070bf569b9c9c95"},
+    {file = "numpy-2.2.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:712a64103d97c404e87d4d7c47fb0c7ff9acccc625ca2002848e0d53288b90ea"},
+    {file = "numpy-2.2.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:a5ae282abe60a2db0fd407072aff4599c279bcd6e9a2475500fc35b00a57c532"},
+    {file = "numpy-2.2.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5266de33d4c3420973cf9ae3b98b54a2a6d53a559310e3236c4b2b06b9c07d4e"},
+    {file = "numpy-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b787adbf04b0db1967798dba8da1af07e387908ed1553a0d6e74c084d1ceafe"},
+    {file = "numpy-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:34c1b7e83f94f3b564b35f480f5652a47007dd91f7c839f404d03279cc8dd021"},
+    {file = "numpy-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4d8335b5f1b6e2bce120d55fb17064b0262ff29b459e8493d1785c18ae2553b8"},
+    {file = "numpy-2.2.3-cp312-cp312-win32.whl", hash = "sha256:4d9828d25fb246bedd31e04c9e75714a4087211ac348cb39c8c5f99dbb6683fe"},
+    {file = "numpy-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:83807d445817326b4bcdaaaf8e8e9f1753da04341eceec705c001ff342002e5d"},
+    {file = "numpy-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7bfdb06b395385ea9b91bf55c1adf1b297c9fdb531552845ff1d3ea6e40d5aba"},
+    {file = "numpy-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:23c9f4edbf4c065fddb10a4f6e8b6a244342d95966a48820c614891e5059bb50"},
+    {file = "numpy-2.2.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:a0c03b6be48aaf92525cccf393265e02773be8fd9551a2f9adbe7db1fa2b60f1"},
+    {file = "numpy-2.2.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:2376e317111daa0a6739e50f7ee2a6353f768489102308b0d98fcf4a04f7f3b5"},
+    {file = "numpy-2.2.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fb62fe3d206d72fe1cfe31c4a1106ad2b136fcc1606093aeab314f02930fdf2"},
+    {file = "numpy-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52659ad2534427dffcc36aac76bebdd02b67e3b7a619ac67543bc9bfe6b7cdb1"},
+    {file = "numpy-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b416af7d0ed3271cad0f0a0d0bee0911ed7eba23e66f8424d9f3dfcdcae1304"},
+    {file = "numpy-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1402da8e0f435991983d0a9708b779f95a8c98c6b18a171b9f1be09005e64d9d"},
+    {file = "numpy-2.2.3-cp313-cp313-win32.whl", hash = "sha256:136553f123ee2951bfcfbc264acd34a2fc2f29d7cdf610ce7daf672b6fbaa693"},
+    {file = "numpy-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:5b732c8beef1d7bc2d9e476dbba20aaff6167bf205ad9aa8d30913859e82884b"},
+    {file = "numpy-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:435e7a933b9fda8126130b046975a968cc2d833b505475e588339e09f7672890"},
+    {file = "numpy-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7678556eeb0152cbd1522b684dcd215250885993dd00adb93679ec3c0e6e091c"},
+    {file = "numpy-2.2.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2e8da03bd561504d9b20e7a12340870dfc206c64ea59b4cfee9fceb95070ee94"},
+    {file = "numpy-2.2.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:c9aa4496fd0e17e3843399f533d62857cef5900facf93e735ef65aa4bbc90ef0"},
+    {file = "numpy-2.2.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4ca91d61a4bf61b0f2228f24bbfa6a9facd5f8af03759fe2a655c50ae2c6610"},
+    {file = "numpy-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:deaa09cd492e24fd9b15296844c0ad1b3c976da7907e1c1ed3a0ad21dded6f76"},
+    {file = "numpy-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:246535e2f7496b7ac85deffe932896a3577be7af8fb7eebe7146444680297e9a"},
+    {file = "numpy-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:daf43a3d1ea699402c5a850e5313680ac355b4adc9770cd5cfc2940e7861f1bf"},
+    {file = "numpy-2.2.3-cp313-cp313t-win32.whl", hash = "sha256:cf802eef1f0134afb81fef94020351be4fe1d6681aadf9c5e862af6602af64ef"},
+    {file = "numpy-2.2.3-cp313-cp313t-win_amd64.whl", hash = "sha256:aee2512827ceb6d7f517c8b85aa5d3923afe8fc7a57d028cffcd522f1c6fd082"},
+    {file = "numpy-2.2.3-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3c2ec8a0f51d60f1e9c0c5ab116b7fc104b165ada3f6c58abf881cb2eb16044d"},
+    {file = "numpy-2.2.3-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:ed2cf9ed4e8ebc3b754d398cba12f24359f018b416c380f577bbae112ca52fc9"},
+    {file = "numpy-2.2.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39261798d208c3095ae4f7bc8eaeb3481ea8c6e03dc48028057d3cbdbdb8937e"},
+    {file = "numpy-2.2.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:783145835458e60fa97afac25d511d00a1eca94d4a8f3ace9fe2043003c678e4"},
+    {file = "numpy-2.2.3.tar.gz", hash = "sha256:dbdc15f0c81611925f382dfa97b3bd0bc2c1ce19d4fe50482cb0ddc12ba30020"},
 ]
 
 [[package]]
@@ -364,6 +364,17 @@ files = [
 ]
 
 [[package]]
+name = "pydicom"
+version = "3.0.1"
+requires_python = ">=3.10"
+summary = "A pure Python package for reading and writing DICOM data"
+groups = ["test"]
+files = [
+    {file = "pydicom-3.0.1-py3-none-any.whl", hash = "sha256:db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41"},
+    {file = "pydicom-3.0.1.tar.gz", hash = "sha256:7b8be344b5b62493c9452ba6f5a299f78f8a6ab79786c729b0613698209603ec"},
+]
+
+[[package]]
 name = "pyflakes"
 version = "3.2.0"
 requires_python = ">=3.8"
@@ -376,7 +387,7 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 requires_python = ">=3.8"
 summary = "pytest: simple powerful testing with Python"
 groups = ["test"]
@@ -389,8 +400,8 @@ dependencies = [
     "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
-    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
   "pytest",
   "numpy",
   "Pillow",
+  "pydicom",
 ]
 quality = [
   "autoflake",

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,7 +1,7 @@
 pub mod manifest;
 pub mod path;
-pub mod tiff;
 pub mod preprocess;
+pub mod tiff;
 
 use pyo3::prelude::*;
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,6 +1,7 @@
 pub mod manifest;
 pub mod path;
 pub mod tiff;
+pub mod preprocess;
 
 use pyo3::prelude::*;
 
@@ -9,5 +10,6 @@ pub fn dicom_preprocessing<'py>(py: Python<'py>, m: &Bound<'py, PyModule>) -> Py
     tiff::register_submodule(py, m)?;
     path::register_submodule(py, m)?;
     manifest::register_submodule(py, m)?;
+    preprocess::register_submodule(py, m)?;
     Ok(())
 }

--- a/src/python/preprocess.rs
+++ b/src/python/preprocess.rs
@@ -1,0 +1,133 @@
+use crate::load::LoadFromTiff;
+use crate::python::path::PyPath;
+use ::tiff::decoder::Decoder;
+use ndarray::Array4;
+use num::Zero;
+use numpy::Element;
+use dicom::object::{open_file, from_reader};
+use numpy::{IntoPyArray, PyArray4};
+use pyo3::prelude::*;
+use pyo3::{
+    exceptions::{PyFileNotFoundError, PyIOError, PyRuntimeError},
+    pymodule,
+    types::{PyAnyMethods, PyList, PyModule},
+    Bound, PyAny, PyResult, Python,
+};
+use rayon::prelude::*;
+use std::clone::Clone;
+use std::fs::File;
+use pyo3::types::PyBytes;
+use pyo3::buffer::PyBuffer;
+use std::io::BufReader;
+use std::path::Path;
+use crate::preprocess::Preprocessor;
+use crate::metadata::preprocessing::PreprocessingMetadata;
+
+#[pymodule]
+#[pyo3(name = "preprocess")]
+pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()> {
+    fn preprocess_stream<'py, T>(
+        py: Python<'py>, 
+        buffer: &PyBuffer<u8>,
+        preprocessor: &Preprocessor,
+    ) -> PyResult<Bound<'py, PyArray4<T>>>
+    where
+        T: Clone + Zero + Element,
+        Array4<T>: LoadFromTiff<T>,
+    {
+        // Check if buffer is readable and contiguous
+        if !buffer.is_c_contiguous() {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "Buffer must be C-contiguous"
+            ));
+        }
+
+        // Create a slice from the buffer and read it into a DICOM object
+        let len = buffer.len_bytes();
+        let ptr = buffer.buf_ptr();
+        let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
+        let dcm = from_reader(bytes).map_err(|_| PyRuntimeError::new_err("Failed to create DICOM object"))?;
+
+        Preprocessor::sanitize_dicom(&mut dcm);
+        let (images, metadata) =
+            preprocessor
+                .prepare_image(&dcm, false)?;
+        let color_type = DicomColorType::try_from(&file).context(DicomSnafu { path: source })?;
+
+        let saver = TiffSaver::new(compressor.into(), color_type);
+        let mut encoder = saver.open_tiff(dest).unwrap();
+        images
+            .into_iter()
+            .try_for_each(|image| saver.save(&mut encoder, &image, &metadata))
+            .context(TiffSnafu { path: dest })?;
+
+
+
+
+        //let file = File::open(path).map_err(|_| PyIOError::new_err("Failed to open file"))?;
+        //let reader = BufReader::new(file);
+        //let mut decoder = Decoder::new(reader)
+        //    .map_err(|_| PyRuntimeError::new_err("Failed to create decoder"))?;
+        //let array = Array4::<T>::decode(&mut decoder)
+        //    .map_err(|_| PyRuntimeError::new_err("Failed to decode TIFF"))?;
+        //Ok(array.into_pyarray_bound(py))
+    }
+
+    fn preprocess_file<'py, T, P>(py: Python<'py>, path: P) -> PyResult<Bound<'py, PyArray4<T>>>
+    where
+        T: Clone + Zero + Element,
+        Array4<T>: LoadFromTiff<T>,
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        if !path.is_file() {
+            return Err(PyFileNotFoundError::new_err(format!(
+                "File not found: {}",
+                path.display()
+            )));
+        }
+
+        let file = File::open(path).map_err(|_| PyIOError::new_err("Failed to open file"))?;
+        let reader = BufReader::new(file);
+        let dcm = open_file()
+
+
+        //let mut decoder = Decoder::new(reader)
+        //    .map_err(|_| PyRuntimeError::new_err("Failed to create decoder"))?;
+        //let array = Array4::<T>::decode(&mut decoder)
+        //    .map_err(|_| PyRuntimeError::new_err("Failed to decode TIFF"))?;
+        //Ok(array.into_pyarray_bound(py))
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "preprocess_u8")]
+    fn preprocess_u8<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyArray4<u8>>> {
+        let path = path.extract::<PyPath>()?;
+        preprocess_file::<u8, _>(py, path)
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "preprocess_u16")]
+    fn preprocess_u16<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyArray4<u16>>> {
+        let path = path.extract::<PyPath>()?;
+        preprocess_file::<u16, _>(py, path)
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "preprocess_f32")]
+    fn preprocess_f32<'py>(
+        py: Python<'py>,
+        path: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyArray4<f32>>> {
+        let path = path.extract::<PyPath>()?;
+        preprocess_file::<f32, _>(py, path)
+    }
+
+    Ok(())
+}

--- a/src/python/preprocess.rs
+++ b/src/python/preprocess.rs
@@ -27,6 +27,7 @@ use tempfile::spooled_tempfile;
 use tiff::encoder::compression::{Compressor, Uncompressed};
 use tiff::encoder::TiffEncoder;
 
+// We guess 64MB as enough for most preprocessed images without being burdensome.
 const SPOOL_SIZE: usize = 1024 * 1024 * 64;
 
 #[pyclass(name = "Preprocessor")]

--- a/src/python/preprocess.rs
+++ b/src/python/preprocess.rs
@@ -1,33 +1,182 @@
+use crate::color::DicomColorType;
 use crate::load::LoadFromTiff;
+use crate::preprocess::Preprocessor;
 use crate::python::path::PyPath;
+use crate::save::TiffSaver;
+use crate::transform::resize::FilterType;
+use crate::transform::volume::{CentralSlice, KeepVolume, VolumeHandler};
+use crate::transform::PaddingDirection;
 use ::tiff::decoder::Decoder;
+use dicom::object::{from_reader, open_file, FileDicomObject, InMemDicomObject};
 use ndarray::Array4;
 use num::Zero;
 use numpy::Element;
-use dicom::object::{open_file, from_reader};
 use numpy::{IntoPyArray, PyArray4};
+use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::{
-    exceptions::{PyFileNotFoundError, PyIOError, PyRuntimeError},
+    exceptions::{PyFileNotFoundError, PyRuntimeError},
     pymodule,
-    types::{PyAnyMethods, PyList, PyModule},
+    types::{PyAnyMethods, PyModule},
     Bound, PyAny, PyResult, Python,
 };
-use rayon::prelude::*;
 use std::clone::Clone;
-use std::fs::File;
-use pyo3::types::PyBytes;
-use pyo3::buffer::PyBuffer;
-use std::io::BufReader;
+use std::io::Seek;
 use std::path::Path;
-use crate::preprocess::Preprocessor;
-use crate::metadata::preprocessing::PreprocessingMetadata;
+use tempfile::spooled_tempfile;
+use tiff::encoder::compression::{Compressor, Uncompressed};
+use tiff::encoder::TiffEncoder;
+
+const SPOOL_SIZE: usize = 1024 * 1024 * 64;
+
+#[pyclass(name = "Preprocessor")]
+#[derive(Clone)]
+pub struct PyPreprocessor {
+    inner: Preprocessor,
+}
+
+#[pymethods]
+impl PyPreprocessor {
+    #[new]
+    #[pyo3(signature = (
+        crop=true,
+        size=None,
+        filter="triangle",
+        padding_direction="zero",
+        crop_max=true,
+        volume_handler="keep",
+        use_components=true,
+        use_padding=true,
+        border_frac=None
+    ))]
+    fn new(
+        crop: bool,
+        size: Option<(u32, u32)>,
+        filter: &str,
+        padding_direction: &str,
+        crop_max: bool,
+        volume_handler: &str,
+        use_components: bool,
+        use_padding: bool,
+        border_frac: Option<f32>,
+    ) -> PyResult<Self> {
+        let filter = match filter.to_lowercase().as_str() {
+            "nearest" => FilterType::Nearest,
+            "triangle" => FilterType::Triangle,
+            "catmull" => FilterType::CatmullRom,
+            "gaussian" => FilterType::Gaussian,
+            "lanczos3" => FilterType::Lanczos3,
+            "maxpool" => FilterType::MaxPool,
+            _ => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid filter type: {}",
+                    filter
+                )))
+            }
+        };
+
+        let padding_direction = match padding_direction.to_lowercase().as_str() {
+            "zero" => PaddingDirection::Zero,
+            "top-left" => PaddingDirection::TopLeft,
+            "bottom-right" => PaddingDirection::BottomRight,
+            "center" => PaddingDirection::Center,
+            _ => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid padding direction: {}",
+                    padding_direction
+                )))
+            }
+        };
+
+        let volume_handler = match volume_handler.to_lowercase().as_str() {
+            "keep" => VolumeHandler::Keep(KeepVolume),
+            "central" => VolumeHandler::CentralSlice(CentralSlice),
+            _ => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid volume handler: {}",
+                    volume_handler
+                )))
+            }
+        };
+
+        Ok(Self {
+            inner: Preprocessor {
+                crop,
+                size,
+                filter,
+                padding_direction,
+                crop_max,
+                volume_handler,
+                use_components,
+                use_padding,
+                border_frac,
+            },
+        })
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "Preprocessor(crop={}, size={:?}, filter={:?}, padding_direction={:?}, crop_max={}, volume_handler={:?}, use_components={}, use_padding={}, border_frac={:?})",
+            self.inner.crop,
+            self.inner.size,
+            self.inner.filter,
+            self.inner.padding_direction,
+            self.inner.crop_max,
+            self.inner.volume_handler,
+            self.inner.use_components,
+            self.inner.use_padding,
+            self.inner.border_frac
+        ))
+    }
+}
+
+/*
+TODO: We preprocess by saving to a temporary TIFF file in memory, then decoding it back to an array.
+It would be faster to directly preprocess the DICOM object without an intermediate TIFF file.
+ */
+fn preprocess_with_temp_tiff<'py, T>(
+    py: Python<'py>,
+    preprocessor: &Preprocessor,
+    dcm: &FileDicomObject<InMemDicomObject>,
+) -> PyResult<Bound<'py, PyArray4<T>>>
+where
+    T: Clone + Zero + Element,
+    Array4<T>: LoadFromTiff<T>,
+{
+    // Run preprocessing
+    let (images, metadata) = preprocessor
+        .prepare_image(&dcm, false)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to prepare image: {}", e)))?;
+
+    // Save the images to an in-memory temporary TIFF file
+    let color_type = DicomColorType::try_from(dcm)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to get color type: {}", e)))?;
+    let compressor = Compressor::Uncompressed(Uncompressed);
+    let saver = TiffSaver::new(compressor.into(), color_type);
+    let mut buffer = spooled_tempfile(SPOOL_SIZE);
+    let mut encoder = TiffEncoder::new(&mut buffer)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to create TIFF encoder: {}", e)))?;
+    images
+        .into_iter()
+        .try_for_each(|image| saver.save(&mut encoder, &image, &metadata))
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to save temporary TIFF: {}", e)))?;
+
+    // Decode the TIFF file back to an array
+    buffer
+        .rewind()
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to rewind buffer: {}", e)))?;
+    let mut decoder = Decoder::new(buffer)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to create decoder: {}", e)))?;
+    let array = Array4::<T>::decode(&mut decoder)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to decode TIFF: {}", e)))?;
+    Ok(array.into_pyarray_bound(py))
+}
 
 #[pymodule]
 #[pyo3(name = "preprocess")]
 pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()> {
     fn preprocess_stream<'py, T>(
-        py: Python<'py>, 
+        py: Python<'py>,
         buffer: &PyBuffer<u8>,
         preprocessor: &Preprocessor,
     ) -> PyResult<Bound<'py, PyArray4<T>>>
@@ -38,7 +187,7 @@ pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>
         // Check if buffer is readable and contiguous
         if !buffer.is_c_contiguous() {
             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "Buffer must be C-contiguous"
+                "Buffer must be C-contiguous",
             ));
         }
 
@@ -46,34 +195,50 @@ pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>
         let len = buffer.len_bytes();
         let ptr = buffer.buf_ptr();
         let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
-        let dcm = from_reader(bytes).map_err(|_| PyRuntimeError::new_err("Failed to create DICOM object"))?;
-
+        let mut dcm = from_reader(bytes)
+            .map_err(|_| PyRuntimeError::new_err("Failed to create DICOM object"))?;
         Preprocessor::sanitize_dicom(&mut dcm);
-        let (images, metadata) =
-            preprocessor
-                .prepare_image(&dcm, false)?;
-        let color_type = DicomColorType::try_from(&file).context(DicomSnafu { path: source })?;
-
-        let saver = TiffSaver::new(compressor.into(), color_type);
-        let mut encoder = saver.open_tiff(dest).unwrap();
-        images
-            .into_iter()
-            .try_for_each(|image| saver.save(&mut encoder, &image, &metadata))
-            .context(TiffSnafu { path: dest })?;
-
-
-
-
-        //let file = File::open(path).map_err(|_| PyIOError::new_err("Failed to open file"))?;
-        //let reader = BufReader::new(file);
-        //let mut decoder = Decoder::new(reader)
-        //    .map_err(|_| PyRuntimeError::new_err("Failed to create decoder"))?;
-        //let array = Array4::<T>::decode(&mut decoder)
-        //    .map_err(|_| PyRuntimeError::new_err("Failed to decode TIFF"))?;
-        //Ok(array.into_pyarray_bound(py))
+        preprocess_with_temp_tiff::<T>(py, preprocessor, &dcm)
     }
 
-    fn preprocess_file<'py, T, P>(py: Python<'py>, path: P) -> PyResult<Bound<'py, PyArray4<T>>>
+    #[pyfn(m)]
+    #[pyo3(name = "preprocess_stream_u8")]
+    fn preprocess_stream_u8<'py>(
+        py: Python<'py>,
+        buffer: &Bound<'py, PyAny>,
+        preprocessor: &PyPreprocessor,
+    ) -> PyResult<Bound<'py, PyArray4<u8>>> {
+        let buffer = buffer.extract::<PyBuffer<u8>>()?;
+        preprocess_stream::<u8>(py, &buffer, &preprocessor.inner)
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "preprocess_stream_u16")]
+    fn preprocess_stream_u16<'py>(
+        py: Python<'py>,
+        buffer: &Bound<'py, PyAny>,
+        preprocessor: &PyPreprocessor,
+    ) -> PyResult<Bound<'py, PyArray4<u16>>> {
+        let buffer = buffer.extract::<PyBuffer<u8>>()?;
+        preprocess_stream::<u16>(py, &buffer, &preprocessor.inner)
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "preprocess_stream_f32")]
+    fn preprocess_stream_f32<'py>(
+        py: Python<'py>,
+        buffer: &Bound<'py, PyAny>,
+        preprocessor: &PyPreprocessor,
+    ) -> PyResult<Bound<'py, PyArray4<f32>>> {
+        let buffer = buffer.extract::<PyBuffer<u8>>()?;
+        preprocess_stream::<f32>(py, &buffer, &preprocessor.inner)
+    }
+
+    fn preprocess_file<'py, T, P>(
+        py: Python<'py>,
+        path: P,
+        preprocessor: &Preprocessor,
+    ) -> PyResult<Bound<'py, PyArray4<T>>>
     where
         T: Clone + Zero + Element,
         Array4<T>: LoadFromTiff<T>,
@@ -87,16 +252,10 @@ pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>
             )));
         }
 
-        let file = File::open(path).map_err(|_| PyIOError::new_err("Failed to open file"))?;
-        let reader = BufReader::new(file);
-        let dcm = open_file()
-
-
-        //let mut decoder = Decoder::new(reader)
-        //    .map_err(|_| PyRuntimeError::new_err("Failed to create decoder"))?;
-        //let array = Array4::<T>::decode(&mut decoder)
-        //    .map_err(|_| PyRuntimeError::new_err("Failed to decode TIFF"))?;
-        //Ok(array.into_pyarray_bound(py))
+        let mut dcm =
+            open_file(path).map_err(|_| PyRuntimeError::new_err("Failed to open DICOM file"))?;
+        Preprocessor::sanitize_dicom(&mut dcm);
+        preprocess_with_temp_tiff::<T>(py, preprocessor, &dcm)
     }
 
     #[pyfn(m)]
@@ -104,9 +263,10 @@ pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>
     fn preprocess_u8<'py>(
         py: Python<'py>,
         path: &Bound<'py, PyAny>,
+        preprocessor: &PyPreprocessor,
     ) -> PyResult<Bound<'py, PyArray4<u8>>> {
         let path = path.extract::<PyPath>()?;
-        preprocess_file::<u8, _>(py, path)
+        preprocess_file::<u8, _>(py, path, &preprocessor.inner)
     }
 
     #[pyfn(m)]
@@ -114,9 +274,10 @@ pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>
     fn preprocess_u16<'py>(
         py: Python<'py>,
         path: &Bound<'py, PyAny>,
+        preprocessor: &PyPreprocessor,
     ) -> PyResult<Bound<'py, PyArray4<u16>>> {
         let path = path.extract::<PyPath>()?;
-        preprocess_file::<u16, _>(py, path)
+        preprocess_file::<u16, _>(py, path, &preprocessor.inner)
     }
 
     #[pyfn(m)]
@@ -124,10 +285,12 @@ pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>
     fn preprocess_f32<'py>(
         py: Python<'py>,
         path: &Bound<'py, PyAny>,
+        preprocessor: &PyPreprocessor,
     ) -> PyResult<Bound<'py, PyArray4<f32>>> {
         let path = path.extract::<PyPath>()?;
-        preprocess_file::<f32, _>(py, path)
+        preprocess_file::<f32, _>(py, path, &preprocessor.inner)
     }
 
+    m.add_class::<PyPreprocessor>()?;
     Ok(())
 }

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,7 +1,7 @@
 use image::DynamicImage;
 use image::GenericImageView;
 use std::fs::File;
-use std::io::BufWriter;
+use std::io::{BufWriter, Seek, Write};
 use std::path::Path;
 use tiff::encoder::colortype::ColorType;
 use tiff::encoder::compression::{Compression, Compressor, Deflate, Packbits};
@@ -24,9 +24,9 @@ where
     C: ColorType,
     D: Compression + Clone,
 {
-    fn save(
+    fn save<T: Write + Seek>(
         &self,
-        encoder: &mut TiffEncoder<BufWriter<File>>,
+        encoder: &mut TiffEncoder<T>,
         image: &DynamicImage,
         metadata: &PreprocessingMetadata,
         compression: D,
@@ -42,9 +42,9 @@ pub struct TiffSaver {
 macro_rules! impl_save_frame {
     ($color_type:ty, $compression:ty, $as_fn:ident) => {
         impl SaveToTiff<$color_type, $compression> for TiffSaver {
-            fn save(
+            fn save<T: Write + Seek>(
                 &self,
-                encoder: &mut TiffEncoder<BufWriter<File>>,
+                encoder: &mut TiffEncoder<T>,
                 image: &DynamicImage,
                 metadata: &PreprocessingMetadata,
                 compression: $compression,
@@ -100,9 +100,9 @@ impl TiffSaver {
         TiffEncoder::new(file).context(WriteSnafu { path: output })
     }
 
-    pub fn save(
+    pub fn save<T: Write + Seek>(
         &self,
-        encoder: &mut TiffEncoder<BufWriter<File>>,
+        encoder: &mut TiffEncoder<T>,
         image: &DynamicImage,
         metadata: &PreprocessingMetadata,
     ) -> Result<(), TiffError> {

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,11 +1,11 @@
+import shutil
 from pathlib import Path
 
-import numpy as np
-import shutil
-import pytest
-import pydicom
 import dicom_preprocessing as dp
-from PIL import Image
+import numpy as np
+import pydicom
+import pytest
+
 
 def test_preprocessor():
     preprocessor = dp.Preprocessor()
@@ -42,6 +42,7 @@ def test_preprocess_u8(dicom_path):
     assert result.min() >= 0
     assert result.max() <= 255
 
+
 def test_preprocess_u16(dicom_path):
     preprocessor = dp.Preprocessor(size=(32, 32))
     result = dp.preprocess_u16(dicom_path, preprocessor)
@@ -49,6 +50,7 @@ def test_preprocess_u16(dicom_path):
     assert result.dtype == np.uint16
     assert result.min() >= 0
     assert result.max() <= 65535
+
 
 def test_preprocess_f32(dicom_path):
     preprocessor = dp.Preprocessor(size=(32, 32))
@@ -58,6 +60,7 @@ def test_preprocess_f32(dicom_path):
     assert result.min() >= 0
     assert result.max() <= 1
 
+
 def test_preprocess_u8_stream(dicom_stream):
     preprocessor = dp.Preprocessor(size=(32, 32))
     result = dp.preprocess_stream_u8(dicom_stream, preprocessor)
@@ -66,6 +69,7 @@ def test_preprocess_u8_stream(dicom_stream):
     assert result.min() >= 0
     assert result.max() <= 255
 
+
 def test_preprocess_u16_stream(dicom_stream):
     preprocessor = dp.Preprocessor(size=(32, 32))
     result = dp.preprocess_stream_u16(dicom_stream, preprocessor)
@@ -73,6 +77,7 @@ def test_preprocess_u16_stream(dicom_stream):
     assert result.dtype == np.uint16
     assert result.min() >= 0
     assert result.max() <= 65535
+
 
 def test_preprocess_f32_stream(dicom_stream):
     preprocessor = dp.Preprocessor(size=(32, 32))

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import numpy as np
+import shutil
+import pytest
+import pydicom
+import dicom_preprocessing as dp
+from PIL import Image
+
+def test_preprocessor():
+    preprocessor = dp.Preprocessor()
+    assert isinstance(repr(preprocessor), str)
+
+
+@pytest.fixture(params=[Path, str])
+def dicom_path(request, tmp_path):
+    path = tmp_path / "test.dcm"
+    source = pydicom.data.get_testdata_file("CT_small.dcm")
+    shutil.copy(source, path)
+    if request.param == Path:
+        return path
+    elif request.param == str:
+        return str(path)
+    else:
+        raise ValueError(f"Invalid parameter: {request.param}")
+
+
+@pytest.fixture
+def dicom_stream(tmp_path):
+    path = tmp_path / "test.dcm"
+    source = pydicom.data.get_testdata_file("CT_small.dcm")
+    shutil.copy(source, path)
+    with open(path, "rb") as f:
+        return f.read()
+
+
+def test_preprocess_u8(dicom_path):
+    preprocessor = dp.Preprocessor(size=(32, 32))
+    result = dp.preprocess_u8(dicom_path, preprocessor)
+    assert result.shape == (1, 32, 32, 1)
+    assert result.dtype == np.uint8
+    assert result.min() >= 0
+    assert result.max() <= 255
+
+def test_preprocess_u16(dicom_path):
+    preprocessor = dp.Preprocessor(size=(32, 32))
+    result = dp.preprocess_u16(dicom_path, preprocessor)
+    assert result.shape == (1, 32, 32, 1)
+    assert result.dtype == np.uint16
+    assert result.min() >= 0
+    assert result.max() <= 65535
+
+def test_preprocess_f32(dicom_path):
+    preprocessor = dp.Preprocessor(size=(32, 32))
+    result = dp.preprocess_f32(dicom_path, preprocessor)
+    assert result.shape == (1, 32, 32, 1)
+    assert result.dtype == np.float32
+    assert result.min() >= 0
+    assert result.max() <= 1
+
+def test_preprocess_u8_stream(dicom_stream):
+    preprocessor = dp.Preprocessor(size=(32, 32))
+    result = dp.preprocess_stream_u8(dicom_stream, preprocessor)
+    assert result.shape == (1, 32, 32, 1)
+    assert result.dtype == np.uint8
+    assert result.min() >= 0
+    assert result.max() <= 255
+
+def test_preprocess_u16_stream(dicom_stream):
+    preprocessor = dp.Preprocessor(size=(32, 32))
+    result = dp.preprocess_stream_u16(dicom_stream, preprocessor)
+    assert result.shape == (1, 32, 32, 1)
+    assert result.dtype == np.uint16
+    assert result.min() >= 0
+    assert result.max() <= 65535
+
+def test_preprocess_f32_stream(dicom_stream):
+    preprocessor = dp.Preprocessor(size=(32, 32))
+    result = dp.preprocess_stream_f32(dicom_stream, preprocessor)
+    assert result.shape == (1, 32, 32, 1)
+    assert result.dtype == np.float32
+    assert result.min() >= 0
+    assert result.max() <= 1


### PR DESCRIPTION
Adds support for inference time preprocessing of DICOMs in Python. An intermediate in-memory TIFF is used as a buffer to hold the preprocessed output before decoding back to an array. Both DICOM file paths and byte streams of DICOMs are supported.