### PR TITLE
Fix moderate bytes vulnerability (CVE-2026-25541)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"


### PR DESCRIPTION
## Summary
- Update transitive dependency `bytes` from 1.11.0 to 1.11.1 to fix integer overflow in `BytesMut::reserve` that can corrupt capacity, leading to out-of-bounds slices and UB in release builds (GHSA-434x-w66g-qw3r)
- No `Cargo.toml` changes needed — `bytes` is pulled in transitively by `arrow-buffer`, `parquet`, and `dicom-ul`

## Test plan
- [x] `cargo build` succeeds
- [x] All 240 tests pass (`cargo test`)
- [x] `cargo tree -i bytes` confirms version 1.11.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)