### PR TITLE
Fix README Mermaid rendering on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ To avoid over-parallelizing across both levels, frame-level parallelism is only 
 
 ```mermaid
 flowchart TD
-    A[Collect input files] --> B[Create rayon thread pool (--threads or system default)]
-    B --> C{Threads per input > 1?}
-    C -->|Yes| D[Enable frame-level decode + transform parallelism]
-    C -->|No| E[Use file-level parallelism only]
-    D --> F[Process each file]
-    E --> F[Process each file]
-    F --> G[Decode]
-    G --> H[Volume handler]
-    H --> I[Crop -> Resize -> Pad]
-    I --> J[Write TIFF]
+    A["Collect input files"] --> B["Create rayon thread pool: --threads or system default"]
+    B --> C{"More than one thread per input?"}
+    C -->|Yes| D["Enable frame-level decode and transform parallelism"]
+    C -->|No| E["Use file-level parallelism only"]
+    D --> F["Process each file"]
+    E --> F
+    F --> G["Decode"]
+    G --> H["Volume handler"]
+    H --> I["Crop, resize, pad"]
+    I --> J["Write TIFF"]
 ```
 
 


### PR DESCRIPTION
## Motivation
The README's parallelization Mermaid diagram did not render correctly on GitHub because some node labels used parser-sensitive characters. That broke a visible piece of project documentation in the main repository landing page.

## Solution
Rewrite the diagram labels into GitHub-safe Mermaid flowchart text by quoting labels and replacing parser-sensitive label content with simpler wording. This preserves the diagram structure while avoiding Mermaid parse errors on GitHub.

## Changes
- Quote Mermaid node labels in the README flowchart
- Replace parser-sensitive label text such as inline parentheses, `>` comparisons, and `->` text inside labels
- Keep the documented parallelization flow unchanged while making the diagram renderable on GitHub

## Test plan
Validated the docs change directly and ran the repository-standard quality gates.
- [x] `npx -y @mermaid-js/mermaid-cli -q -i README.md -o /tmp/readme-mermaid.svg`
- [x] `make quality`
- [x] `make test`

Generated with Codex