### PR TITLE
Optimize component crop bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,7 @@ harness = false
 [[bench]]
 name = "dbt_parallel"
 harness = false
+
+[[bench]]
+name = "crop"
+harness = false

--- a/benches/crop.rs
+++ b/benches/crop.rs
@@ -1,0 +1,112 @@
+use criterion::{
+    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
+    Throughput,
+};
+use dicom_preprocessing::Crop;
+use image::{DynamicImage, ImageBuffer, Luma};
+use std::hint::black_box;
+use std::time::Duration;
+
+const WIDTH: u32 = 2048;
+const HEIGHT: u32 = 1536;
+const FRAME_COUNT: usize = 8;
+const FOREGROUND_LEFT: u32 = 280;
+const FOREGROUND_TOP: u32 = 160;
+const FOREGROUND_WIDTH: u32 = 1420;
+const FOREGROUND_HEIGHT: u32 = 1180;
+const ARTIFACT_SIZE: u32 = 24;
+const FOREGROUND_VALUE: u16 = 32_000;
+const ARTIFACT_VALUE: u16 = 48_000;
+const SAMPLE_SIZE: usize = 10;
+const SINGLE_FRAME_LABEL: &str = "2048x1536";
+const MULTI_FRAME_LABEL: &str = "8x2048x1536";
+
+fn in_rect(x: u32, y: u32, left: u32, top: u32, width: u32, height: u32) -> bool {
+    x >= left && x < left + width && y >= top && y < top + height
+}
+
+fn synthetic_mammography_frame(frame_idx: usize) -> DynamicImage {
+    let shift = frame_idx as u32 % 7;
+    let image = ImageBuffer::from_fn(WIDTH, HEIGHT, |x, y| {
+        let foreground = in_rect(
+            x,
+            y,
+            FOREGROUND_LEFT + shift,
+            FOREGROUND_TOP,
+            FOREGROUND_WIDTH,
+            FOREGROUND_HEIGHT,
+        );
+        let artifact = in_rect(x, y, 48 + shift, 64, ARTIFACT_SIZE, ARTIFACT_SIZE)
+            || in_rect(
+                x,
+                y,
+                WIDTH - 96,
+                HEIGHT - 96 - shift,
+                ARTIFACT_SIZE,
+                ARTIFACT_SIZE,
+            );
+
+        let value = if foreground {
+            FOREGROUND_VALUE + (x.wrapping_add(y) % 1024) as u16
+        } else if artifact {
+            ARTIFACT_VALUE
+        } else {
+            0
+        };
+
+        Luma([value])
+    });
+
+    DynamicImage::ImageLuma16(image)
+}
+
+fn synthetic_frames() -> Vec<DynamicImage> {
+    (0..FRAME_COUNT).map(synthetic_mammography_frame).collect()
+}
+
+fn bench_crop_case(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    bench_name: &'static str,
+    bench_label: &'static str,
+    images: &[&DynamicImage],
+) {
+    group.throughput(Throughput::Elements(
+        (WIDTH as u64) * (HEIGHT as u64) * images.len() as u64,
+    ));
+    group.bench_with_input(
+        BenchmarkId::new(bench_name, bench_label),
+        images,
+        |b, images| {
+            b.iter(|| black_box(Crop::new_from_images(black_box(images), true, true, None)))
+        },
+    );
+}
+
+fn bench_component_crop(c: &mut Criterion) {
+    let frames = synthetic_frames();
+    let single_frame = vec![&frames[0]];
+    let multi_frame: Vec<&DynamicImage> = frames.iter().collect();
+
+    let mut group = c.benchmark_group("component-crop");
+    group.sample_size(SAMPLE_SIZE);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(3));
+
+    bench_crop_case(
+        &mut group,
+        "single_frame_luma16",
+        SINGLE_FRAME_LABEL,
+        &single_frame,
+    );
+    bench_crop_case(
+        &mut group,
+        "multi_frame_luma16",
+        MULTI_FRAME_LABEL,
+        &multi_frame,
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_component_crop);
+criterion_main!(benches);

--- a/src/transform/crop.rs
+++ b/src/transform/crop.rs
@@ -2,7 +2,6 @@ use image::imageops::FilterType;
 use image::{DynamicImage, GenericImageView, Luma, Pixel};
 use imageproc::contrast::{threshold, ThresholdType};
 use imageproc::region_labelling::{connected_components, Connectivity};
-use itertools::Itertools;
 use std::io::{Read, Seek, Write};
 use tiff::decoder::Decoder;
 use tiff::encoder::colortype::ColorType;
@@ -19,6 +18,42 @@ pub const DEFAULT_CROP_SIZE: u16 = 50720;
 const DEFAULT_CHECK_MAX: bool = false;
 const DEFAULT_RESIZE_SIZE: u32 = 512;
 const NONZERO_THRESHOLD: u8 = 1;
+
+#[derive(Clone, Copy, Debug)]
+struct ComponentBounds {
+    count: usize,
+    left: u32,
+    right: u32,
+    top: u32,
+    bottom: u32,
+}
+
+impl ComponentBounds {
+    fn empty() -> Self {
+        Self {
+            count: 0,
+            left: u32::MAX,
+            right: 0,
+            top: u32::MAX,
+            bottom: 0,
+        }
+    }
+
+    fn include(&mut self, x: u32, y: u32) {
+        if self.count == 0 {
+            self.left = x;
+            self.right = x;
+            self.top = y;
+            self.bottom = y;
+        } else {
+            self.left = self.left.min(x);
+            self.right = self.right.max(x);
+            self.top = self.top.min(y);
+            self.bottom = self.bottom.max(y);
+        }
+        self.count += 1;
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Crop {
@@ -93,8 +128,7 @@ impl Crop {
         border_frac: Option<f32>,
     ) -> Self {
         // First generate a baseline crop
-        let image = image.clone();
-        let crop = Crop::new(&image, check_max, border_frac);
+        let crop = Crop::new(image, check_max, border_frac);
         let thumbnail = image.crop_imm(crop.left, crop.top, crop.width, crop.height);
 
         // Resize the image to smaller size for fast computation of crop boundaries
@@ -119,25 +153,34 @@ impl Crop {
         let bg = Luma([0]);
         let components = connected_components(&thumbnail, Connectivity::Four, bg);
 
-        // Find the largest connected component
-        let (max_component, _) = components
-            .iter()
-            .filter(|&&c| c > 0)
-            .counts()
-            .into_iter()
-            .max_by_key(|&(_, count)| count)
-            .unwrap_or((&0, 0));
+        let mut component_bounds = Vec::<ComponentBounds>::new();
+        for (x, y, component) in components.enumerate_pixels() {
+            let label = component[0] as usize;
+            if label == 0 {
+                continue;
+            }
+            if component_bounds.len() <= label {
+                component_bounds.resize_with(label + 1, ComponentBounds::empty);
+            }
+            component_bounds[label].include(x, y);
+        }
 
-        // Compute crop bounds from the largest connected component
-        let (left, right, top, bottom) = components
-            .enumerate_pixels()
-            .filter(|&(_, _, c)| c[0] == *max_component)
-            .fold(
-                (thumbnail.width() - 1, 0, thumbnail.height() - 1, 0),
-                |(min_x, max_x, min_y, max_y), (x, y, _)| {
-                    (min_x.min(x), max_x.max(x), min_y.min(y), max_y.max(y))
-                },
-            );
+        let largest_component = component_bounds
+            .iter()
+            .copied()
+            .filter(|component| component.count > 0)
+            .max_by_key(|component| component.count);
+
+        let (left, right, top, bottom) = largest_component
+            .map(|component| {
+                (
+                    component.left,
+                    component.right,
+                    component.top,
+                    component.bottom,
+                )
+            })
+            .unwrap_or((0, thumbnail.width() - 1, 0, thumbnail.height() - 1));
 
         // Determine scale factor between resized and original cropped image
         let orig_width = crop.width;
@@ -390,6 +433,18 @@ mod tests {
     use tiff::decoder::Decoder as TiffDecoder;
     use tiff::encoder::TiffEncoder;
 
+    fn rgba_image_from_rows<R: AsRef<[u8]>>(rows: &[R]) -> DynamicImage {
+        let width = rows[0].as_ref().len() as u32;
+        let height = rows.len() as u32;
+        let mut img = RgbaImage::new(width, height);
+        for (y, row) in rows.iter().enumerate() {
+            for (x, &value) in row.as_ref().iter().enumerate() {
+                img.put_pixel(x as u32, y as u32, image::Rgba([value, value, value, 255]));
+            }
+        }
+        DynamicImage::ImageRgba8(img)
+    }
+
     #[rstest]
     #[case(
         vec![
@@ -436,24 +491,10 @@ mod tests {
         #[case] crop_max: bool,
         #[case] expected_crop: (u32, u32, u32, u32),
     ) {
-        // Create a new image from the pixel data
-        let width = pixels[0].len() as u32;
-        let height = pixels.len() as u32;
-        let mut img = RgbaImage::new(width, height);
-        for (y, row) in pixels.iter().enumerate() {
-            for (x, &value) in row.iter().enumerate() {
-                img.put_pixel(x as u32, y as u32, image::Rgba([value, value, value, 255]));
-            }
-        }
-        let dynamic_image = DynamicImage::ImageRgba8(img);
+        let dynamic_image = rgba_image_from_rows(&pixels);
 
         let crop = Crop::new(&dynamic_image, crop_max, None);
-        let expected_crop = Crop {
-            left: expected_crop.0,
-            top: expected_crop.1,
-            width: expected_crop.2,
-            height: expected_crop.3,
-        };
+        let expected_crop = expected_crop.into();
         assert_eq!(crop, expected_crop);
     }
 
@@ -503,25 +544,38 @@ mod tests {
         #[case] check_max: bool,
         #[case] expected_crop: (u32, u32, u32, u32),
     ) {
-        // Create a new image from the pixel data
-        let width = pixels[0].len() as u32;
-        let height = pixels.len() as u32;
-        let mut img = RgbaImage::new(width, height);
-        for (y, row) in pixels.iter().enumerate() {
-            for (x, &value) in row.iter().enumerate() {
-                img.put_pixel(x as u32, y as u32, image::Rgba([value, value, value, 255]));
-            }
-        }
-        let dynamic_image = DynamicImage::ImageRgba8(img);
+        let dynamic_image = rgba_image_from_rows(&pixels);
 
         let crop = Crop::new_from_components(&dynamic_image, check_max, None);
-        let expected_crop = Crop {
-            left: expected_crop.0,
-            top: expected_crop.1,
-            width: expected_crop.2,
-            height: expected_crop.3,
-        };
+        let expected_crop = expected_crop.into();
         assert_eq!(crop, expected_crop);
+    }
+
+    #[test]
+    fn test_new_from_components_selects_largest_foreground_component() {
+        let pixels = [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 7, 7, 0, 0, 0, 0, 0],
+            [0, 7, 7, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 9, 9, 9, 0],
+            [0, 0, 0, 0, 9, 9, 9, 0],
+            [0, 0, 0, 0, 9, 9, 9, 0],
+            [0, 0, 0, 0, 9, 9, 9, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ];
+        let dynamic_image = rgba_image_from_rows(&pixels);
+
+        let crop = Crop::new_from_components(&dynamic_image, false, None);
+
+        assert_eq!(
+            crop,
+            Crop {
+                left: 4,
+                top: 3,
+                width: 3,
+                height: 4,
+            }
+        );
     }
 
     #[rstest]
@@ -653,24 +707,10 @@ mod tests {
         #[case] check_max: bool,
         #[case] expected_crop: (u32, u32, u32, u32),
     ) {
-        // Create a new image from the pixel data
-        let width = pixels[0].len() as u32;
-        let height = pixels.len() as u32;
-        let mut img = RgbaImage::new(width, height);
-        for (y, row) in pixels.iter().enumerate() {
-            for (x, &value) in row.iter().enumerate() {
-                img.put_pixel(x as u32, y as u32, image::Rgba([value, value, value, 255]));
-            }
-        }
-        let dynamic_image = DynamicImage::ImageRgba8(img);
+        let dynamic_image = rgba_image_from_rows(&pixels);
 
         let crop = Crop::new(&dynamic_image, check_max, Some(border_frac));
-        let expected_crop = Crop {
-            left: expected_crop.0,
-            top: expected_crop.1,
-            width: expected_crop.2,
-            height: expected_crop.3,
-        };
+        let expected_crop = expected_crop.into();
         assert_eq!(crop, expected_crop);
     }
 
@@ -728,24 +768,10 @@ mod tests {
         #[case] check_max: bool,
         #[case] expected_crop: (u32, u32, u32, u32),
     ) {
-        // Create a new image from the pixel data
-        let width = pixels[0].len() as u32;
-        let height = pixels.len() as u32;
-        let mut img = RgbaImage::new(width, height);
-        for (y, row) in pixels.iter().enumerate() {
-            for (x, &value) in row.iter().enumerate() {
-                img.put_pixel(x as u32, y as u32, image::Rgba([value, value, value, 255]));
-            }
-        }
-        let dynamic_image = DynamicImage::ImageRgba8(img);
+        let dynamic_image = rgba_image_from_rows(&pixels);
 
         let crop = Crop::new_from_images(&[&dynamic_image], check_max, true, border_frac);
-        let expected_crop = Crop {
-            left: expected_crop.0,
-            top: expected_crop.1,
-            width: expected_crop.2,
-            height: expected_crop.3,
-        };
+        let expected_crop = expected_crop.into();
         assert_eq!(crop, expected_crop);
     }
 }


### PR DESCRIPTION
## Motivation
Default preprocessing uses component-based crop detection, which scans image content before resize and padding. The existing implementation made an unnecessary full-image clone and performed separate connected-component count and bounds scans, adding avoidable CPU and allocation cost on high-resolution mammography-like frames.

## Solution
The crop path now keeps the source image borrowed, records component count and bounds in one pass over the connected-component label image, and selects the largest foreground component from that summary. A Criterion benchmark covers the single-frame and multi-frame component-crop workloads.

## Changes
- Add a `crop` Criterion benchmark for 2048x1536 synthetic Luma16 component-crop workloads.
- Remove the unnecessary `DynamicImage` clone in `Crop::new_from_components`.
- Replace the `counts()` pass plus second bounds scan with a single component-bounds accumulation pass.
- Add a largest-component regression test and clean up repeated crop test fixture setup.

## Test plan
- [x] `cargo test transform::crop::tests`
- [x] `cargo check --benches`
- [x] `cargo clippy --benches -- -D warnings`
- [x] `PATH="$PWD/.venv/bin:$PATH" make quality`
- [x] `PATH="$PWD/.venv/bin:$PATH" make test`
- [x] `cargo bench --bench crop`

Benchmark summary from `cargo bench --bench crop`:

| Case | Baseline mean | Optimized mean | Change |
| --- | ---: | ---: | ---: |
| single_frame_luma16 / 2048x1536 | 10.974 ms | 6.8359 ms | 37.69% faster |
| multi_frame_luma16 / 8x2048x1536 | 93.710 ms | 56.781 ms | 39.37% faster |

## Test suite changes
- [x] Added `test_new_from_components_selects_largest_foreground_component` to lock in largest-foreground-component selection.
- [x] No tests were removed.
- [x] Existing crop tests had duplicate fixture construction replaced with a helper; assertions and coverage intent are unchanged.

Generated with Codex.