### PR TITLE
Optimize Luma16 padding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,3 +103,7 @@ harness = false
 [[bench]]
 name = "crop"
 harness = false
+
+[[bench]]
+name = "pad"
+harness = false

--- a/benches/pad.rs
+++ b/benches/pad.rs
@@ -1,0 +1,52 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use dicom_preprocessing::{Padding, Transform};
+use image::{DynamicImage, ImageBuffer, Luma};
+use std::hint::black_box;
+use std::time::Duration;
+
+const WIDTH: u32 = 2048;
+const HEIGHT: u32 = 1536;
+const TARGET_WIDTH: u32 = 2304;
+const TARGET_HEIGHT: u32 = 1792;
+const PADDING_WIDTH: u32 = TARGET_WIDTH - WIDTH;
+const PADDING_HEIGHT: u32 = TARGET_HEIGHT - HEIGHT;
+const PADDING_LEFT: u32 = PADDING_WIDTH / 2;
+const PADDING_TOP: u32 = PADDING_HEIGHT / 2;
+const PADDING: Padding = Padding {
+    left: PADDING_LEFT,
+    top: PADDING_TOP,
+    right: PADDING_WIDTH - PADDING_LEFT,
+    bottom: PADDING_HEIGHT - PADDING_TOP,
+};
+const SAMPLE_SIZE: usize = 10;
+
+fn synthetic_luma16_frame() -> DynamicImage {
+    let image = ImageBuffer::from_fn(WIDTH, HEIGHT, |x, y| {
+        let value = ((x.wrapping_mul(31) + y.wrapping_mul(17)) % u16::MAX as u32) as u16;
+        Luma([value])
+    });
+
+    DynamicImage::ImageLuma16(image)
+}
+
+fn bench_padding(c: &mut Criterion) {
+    let image = synthetic_luma16_frame();
+    let bench_label = format!("{WIDTH}x{HEIGHT}_to_{TARGET_WIDTH}x{TARGET_HEIGHT}");
+
+    let mut group = c.benchmark_group("padding");
+    group.sample_size(SAMPLE_SIZE);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(3));
+    group.throughput(Throughput::Elements(
+        (TARGET_WIDTH as u64) * (TARGET_HEIGHT as u64),
+    ));
+    group.bench_with_input(
+        BenchmarkId::new("apply_luma16_center", bench_label),
+        &image,
+        |b, image| b.iter(|| black_box(PADDING.apply(black_box(image)))),
+    );
+    group.finish();
+}
+
+criterion_group!(benches, bench_padding);
+criterion_main!(benches);

--- a/src/transform/pad.rs
+++ b/src/transform/pad.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, GenericImage, GenericImageView, Pixel};
+use image::{DynamicImage, GenericImage, GenericImageView, ImageBuffer, Luma, Pixel};
 use std::fmt;
 use std::io::{Read, Seek, Write};
 use tiff::decoder::Decoder;
@@ -12,6 +12,8 @@ use crate::metadata::WriteTags;
 use crate::transform::{Coord, InvertibleTransform, Transform};
 
 pub const ACTIVE_AREA: u16 = 50829;
+
+type Luma16Image = ImageBuffer<Luma<u16>, Vec<u16>>;
 
 #[derive(Clone, Debug, clap::ValueEnum, Default, Copy)]
 pub enum PaddingDirection {
@@ -112,10 +114,43 @@ impl Padding {
             }
         }
     }
+
+    fn apply_luma16(&self, image: &Luma16Image) -> DynamicImage {
+        let (source_width_px, source_height_px) = image.dimensions();
+        let destination_width_px = source_width_px + self.left + self.right;
+        let destination_height_px = source_height_px + self.top + self.bottom;
+        let mut padded_image = Luma16Image::new(destination_width_px, destination_height_px);
+
+        let source_width = source_width_px as usize;
+        let source_height = source_height_px as usize;
+        let destination_width = destination_width_px as usize;
+        let left_offset = self.left as usize;
+        let top_offset = self.top as usize;
+        let source = image.as_flat_samples().samples;
+
+        {
+            let destination = padded_image.as_flat_samples_mut().samples;
+
+            for row in 0..source_height {
+                let source_start = row * source_width;
+                let source_end = source_start + source_width;
+                let destination_start = (row + top_offset) * destination_width + left_offset;
+                let destination_end = destination_start + source_width;
+                destination[destination_start..destination_end]
+                    .copy_from_slice(&source[source_start..source_end]);
+            }
+        }
+
+        DynamicImage::ImageLuma16(padded_image)
+    }
 }
 
 impl Transform<DynamicImage> for Padding {
     fn apply(&self, image: &DynamicImage) -> DynamicImage {
+        if let DynamicImage::ImageLuma16(image) = image {
+            return self.apply_luma16(image);
+        }
+
         let (width, height) = image.dimensions();
         let mut padded_image = DynamicImage::new(
             width + self.left + self.right,
@@ -211,7 +246,7 @@ impl TryFrom<Vec<u32>> for Padding {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use image::{DynamicImage, RgbaImage};
+    use image::{DynamicImage, ImageBuffer, Luma, RgbaImage};
     use rstest::rstest;
     use std::fs::File;
     use tempfile::tempdir;
@@ -360,6 +395,45 @@ mod tests {
             .collect();
 
         assert_eq!(padded_pixels, expected_pixels);
+    }
+
+    #[test]
+    fn test_pad_luma16_fast_path() {
+        const WIDTH: u32 = 3;
+        const HEIGHT: u32 = 2;
+        const PADDING: Padding = Padding {
+            left: 1,
+            top: 2,
+            right: 2,
+            bottom: 1,
+        };
+        const OUTPUT_WIDTH: u32 = WIDTH + PADDING.left + PADDING.right;
+        const OUTPUT_HEIGHT: u32 = HEIGHT + PADDING.top + PADDING.bottom;
+
+        fn pixel_value(x: u32, y: u32) -> u16 {
+            (y * WIDTH + x + 1) as u16
+        }
+
+        let image = ImageBuffer::from_fn(WIDTH, HEIGHT, |x, y| Luma([pixel_value(x, y)]));
+        let dynamic_image = DynamicImage::ImageLuma16(image);
+
+        let padded_image = PADDING.apply(&dynamic_image);
+        let padded = padded_image
+            .as_luma16()
+            .expect("Padding Luma16 input should preserve Luma16 color type");
+        assert_eq!(padded.dimensions(), (OUTPUT_WIDTH, OUTPUT_HEIGHT));
+
+        let mut expected = vec![0_u16; (OUTPUT_WIDTH * OUTPUT_HEIGHT) as usize];
+        for y in 0..HEIGHT {
+            for x in 0..WIDTH {
+                let destination_x = x + PADDING.left;
+                let destination_y = y + PADDING.top;
+                let destination_index = (destination_y * OUTPUT_WIDTH + destination_x) as usize;
+                expected[destination_index] = pixel_value(x, y);
+            }
+        }
+
+        assert_eq!(padded.as_raw().as_slice(), expected.as_slice());
     }
 
     #[rstest]


### PR DESCRIPTION
## Motivation
Padding is part of the preprocessing path when output dimensions require padded frames. The common 16-bit grayscale image path was still using the generic `DynamicImage` per-pixel `get_pixel`/`put_pixel` loop, which made large frame padding much slower than necessary.

## Solution
Add a Criterion benchmark for representative large Luma16 padding and specialize `Padding::apply` for `ImageLuma16`. The specialized path allocates the same zero-filled destination image and copies each contiguous source row into its padded destination slice, while all non-Luma16 image variants keep the existing generic fallback.

## Changes
- Add `cargo bench --bench pad` for a `2048x1536` Luma16 frame padded to `2304x1792`.
- Add a Luma16 row-copy fast path in `Padding::apply`.
- Add a focused unit test for Luma16 padding output shape, type preservation, zero padding, and copied pixel placement.
- Keep public APIs, CLI behavior, Python bindings, and metadata formats unchanged.

## Test plan
- [x] `cargo test --lib transform::pad::tests`
- [x] `cargo clippy --bench pad --all-features -- -D warnings`
- [x] `cargo bench --bench pad`
- [x] `make quality`
- [x] `make test`

Benchmark result after cleanup: `249.02-250.42 us`, `16.537 Gelem/s` midpoint for `padding/apply_luma16_center/2048x1536_to_2304x1792`.

## Test suite changes (Required when test coverage changed)
- Added `transform::pad::tests::test_pad_luma16_fast_path` to cover the new Luma16 fast path.
- No tests were removed or significantly altered.

Generated with Codex.