### PR TITLE
Add Node display-frame rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,17 +271,20 @@ if not report["summary"]["valid"]:
 
 ### Node/TypeScript Bindings
 
-Node bindings are provided under `bindings/node` with NAPI-RS. The package name is `@medcognetics/dicom-preprocessing`, and the viewer path exposes the same frame-plan and raw-frame contract as the Rust `ViewerDicom` API without crop, resize, or pad.
+Node bindings are provided under `bindings/node` with NAPI-RS. The package name is `@medcognetics/dicom-preprocessing`, and the viewer path exposes the same frame-plan contract as the Rust `ViewerDicom` API without crop, resize, or pad.
 
 ```ts
-import { prepareDicom, renderFrame } from '@medcognetics/dicom-preprocessing'
+import { prepareDicom, renderDisplayFrame, renderFrame } from '@medcognetics/dicom-preprocessing'
 
 const prepared = prepareDicom({ path: '/path/to/image.dcm' })
-const frame = renderFrame(prepared, 0)
-console.log(frame.width, frame.height, frame.dtype, frame.source)
+const raw = renderFrame(prepared, 0)
+const display = renderDisplayFrame(prepared, 0)
+console.log(display.width, display.height, display.dtype, display.source)
 ```
 
-`frame.data` is a Node `Buffer` containing raw stored-frame bytes. NAPI-RS can transfer Rust-owned buffers without copying in standard Node runtimes, but Electron may copy buffers because of V8 memory-cage constraints.
+`renderFrame` returns raw stored-frame bytes and rejects derived display frames because they have no exact stored-frame source.
+`renderDisplayFrame` returns the display-frame pixels, including derived volume-handler outputs such as `laplacian-mip`.
+Frame data is returned as a Node `Buffer`. NAPI-RS can transfer Rust-owned buffers without copying in standard Node runtimes, but Electron may copy buffers because of V8 memory-cage constraints.
 
 
 ### CT Scan Stacking

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -50,6 +50,7 @@ export interface RenderedFrame extends FrameMetadata {
 export declare class PreparedDicom {
   get framePlan(): FramePlan
   renderFrame(frameIndex: number): RenderedFrame
+  renderDisplayFrame(frameIndex: number): RenderedFrame
 }
 
 export interface NodeFramePlan {
@@ -81,5 +82,7 @@ export interface NodeRenderedFrame {
 }
 
 export declare function prepareDicom(input: DicomInput, options?: PrepareOptions): PreparedDicom
+
+export declare function renderDisplayFrame(prepared: PreparedDicom, frameIndex: number): RenderedFrame
 
 export declare function renderFrame(prepared: PreparedDicom, frameIndex: number): RenderedFrame

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -589,4 +589,5 @@ if (!nativeBinding) {
 module.exports = nativeBinding
 module.exports.PreparedDicom = nativeBinding.PreparedDicom
 module.exports.prepareDicom = nativeBinding.prepareDicom
+module.exports.renderDisplayFrame = nativeBinding.renderDisplayFrame
 module.exports.renderFrame = nativeBinding.renderFrame

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -1,6 +1,7 @@
 use std::io::Cursor;
 
 use dicom::object::from_reader;
+use dicom::pixeldata::ConvertOptions;
 use dicom_preprocessing::{
     metadata::pixel_spacing_mm, DicomError, FrameOrderStrategy, ViewerDicom, VolumeFrameSource,
     VolumeHandler,
@@ -70,7 +71,15 @@ impl PreparedDicom {
         &self,
         frame_index: Unknown<'_>,
     ) -> std::result::Result<NodeRenderedFrame, Error<String>> {
-        render_prepared_frame(self, parse_frame_index(frame_index)?)
+        render_raw_prepared_frame(self, parse_frame_index(frame_index)?)
+    }
+
+    #[napi(ts_args_type = "frameIndex: number", ts_return_type = "RenderedFrame")]
+    pub fn render_display_frame(
+        &self,
+        frame_index: Unknown<'_>,
+    ) -> std::result::Result<NodeRenderedFrame, Error<String>> {
+        render_prepared_display_frame(self, parse_frame_index(frame_index)?)
     }
 }
 
@@ -96,14 +105,25 @@ pub fn render_frame(
     prepared: &PreparedDicom,
     frame_index: Unknown<'_>,
 ) -> std::result::Result<NodeRenderedFrame, Error<String>> {
-    render_prepared_frame(prepared, parse_frame_index(frame_index)?)
+    render_raw_prepared_frame(prepared, parse_frame_index(frame_index)?)
 }
 
-fn render_prepared_frame(
+#[napi(
+    ts_args_type = "prepared: PreparedDicom, frameIndex: number",
+    ts_return_type = "RenderedFrame"
+)]
+pub fn render_display_frame(
+    prepared: &PreparedDicom,
+    frame_index: Unknown<'_>,
+) -> std::result::Result<NodeRenderedFrame, Error<String>> {
+    render_prepared_display_frame(prepared, parse_frame_index(frame_index)?)
+}
+
+fn display_frame_source(
     prepared: &PreparedDicom,
     frame_index: u32,
-) -> std::result::Result<NodeRenderedFrame, Error<String>> {
-    let source = prepared
+) -> std::result::Result<VolumeFrameSource, Error<String>> {
+    prepared
         .viewer
         .frame_plan()
         .display_frames
@@ -114,14 +134,19 @@ fn render_prepared_frame(
                 CODE_FRAME_INDEX_OUT_OF_RANGE,
                 format!("display frame index {frame_index} is out of range"),
             )
-        })?;
+        })
+}
+
+fn render_raw_prepared_frame(
+    prepared: &PreparedDicom,
+    frame_index: u32,
+) -> std::result::Result<NodeRenderedFrame, Error<String>> {
+    let source = display_frame_source(prepared, frame_index)?;
     let raw = prepared
         .viewer
         .decode_raw_display_frame(frame_index as usize)
         .map_err(map_dicom_render_error)?;
     let dtype = dtype_for_frame(raw.bits_allocated, raw.pixel_representation_signed)?;
-    let pixel_spacing = pixel_spacing_mm(prepared.viewer.file())
-        .map(|[row_mm, column_mm]| vec![f64::from(column_mm), f64::from(row_mm)]);
 
     Ok(NodeRenderedFrame {
         display_frame_index: frame_index,
@@ -132,12 +157,83 @@ fn render_prepared_frame(
         dtype: dtype.to_string(),
         samples_per_pixel: u32::from(raw.samples_per_pixel),
         photometric_interpretation: raw.photometric_interpretation,
-        pixel_spacing,
+        pixel_spacing: node_pixel_spacing(&prepared.viewer),
         rescale_slope: raw.rescale_slope,
         rescale_intercept: raw.rescale_intercept,
         window_center: raw.window_center,
         window_width: raw.window_width,
     })
+}
+
+fn render_prepared_display_frame(
+    prepared: &PreparedDicom,
+    frame_index: u32,
+) -> std::result::Result<NodeRenderedFrame, Error<String>> {
+    let source = display_frame_source(prepared, frame_index)?;
+    match source {
+        VolumeFrameSource::StoredFrame { .. } => render_raw_prepared_frame(prepared, frame_index),
+        VolumeFrameSource::Derived => render_derived_display_frame(prepared, frame_index, source),
+    }
+}
+
+fn render_derived_display_frame(
+    prepared: &PreparedDicom,
+    frame_index: u32,
+    source: VolumeFrameSource,
+) -> std::result::Result<NodeRenderedFrame, Error<String>> {
+    let image = prepared
+        .viewer
+        .decode_display_frame_with_options(frame_index as usize, &ConvertOptions::default())
+        .map_err(map_dicom_render_error)?;
+    let width = image.width();
+    let height = image.height();
+    let (data, dtype, samples_per_pixel, photometric_interpretation) =
+        if let Some(image) = image.as_luma8() {
+            (
+                image.as_raw().clone(),
+                "uint8",
+                1_u32,
+                "MONOCHROME2".to_string(),
+            )
+        } else if let Some(image) = image.as_luma16() {
+            let data = image
+                .as_raw()
+                .iter()
+                .flat_map(|value| u16::to_le_bytes(*value))
+                .collect();
+            (data, "uint16", 1_u32, "MONOCHROME2".to_string())
+        } else if let Some(image) = image.as_rgb8() {
+            (image.as_raw().clone(), "uint8", 3_u32, "RGB".to_string())
+        } else {
+            return Err(js_error(
+                CODE_UNSUPPORTED_IMAGE_LAYOUT,
+                format!(
+                    "unsupported derived display frame color type: {:?}",
+                    image.color()
+                ),
+            ));
+        };
+
+    Ok(NodeRenderedFrame {
+        display_frame_index: frame_index,
+        source: node_frame_source(source),
+        data: data.into(),
+        width,
+        height,
+        dtype: dtype.to_string(),
+        samples_per_pixel,
+        photometric_interpretation,
+        pixel_spacing: node_pixel_spacing(&prepared.viewer),
+        rescale_slope: 1.0,
+        rescale_intercept: 0.0,
+        window_center: None,
+        window_width: None,
+    })
+}
+
+fn node_pixel_spacing(viewer: &ViewerDicom) -> Option<Vec<f64>> {
+    pixel_spacing_mm(viewer.file())
+        .map(|[row_mm, column_mm]| vec![f64::from(column_mm), f64::from(row_mm)])
 }
 
 fn parse_dicom_input(

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -187,31 +187,36 @@ fn render_derived_display_frame(
         .map_err(map_dicom_render_error)?;
     let width = image.width();
     let height = image.height();
+    let color = image.color();
     let (data, dtype, samples_per_pixel, photometric_interpretation) =
-        if let Some(image) = image.as_luma8() {
-            (
-                image.as_raw().clone(),
+        match (color.channel_count(), color.bits_per_pixel()) {
+            (1, 8) => (
+                image.into_luma8().into_raw(),
                 "uint8",
                 1_u32,
                 "MONOCHROME2".to_string(),
-            )
-        } else if let Some(image) = image.as_luma16() {
-            let data = image
-                .as_raw()
-                .iter()
-                .flat_map(|value| u16::to_le_bytes(*value))
-                .collect();
-            (data, "uint16", 1_u32, "MONOCHROME2".to_string())
-        } else if let Some(image) = image.as_rgb8() {
-            (image.as_raw().clone(), "uint8", 3_u32, "RGB".to_string())
-        } else {
-            return Err(js_error(
-                CODE_UNSUPPORTED_IMAGE_LAYOUT,
-                format!(
-                    "unsupported derived display frame color type: {:?}",
-                    image.color()
-                ),
-            ));
+            ),
+            (1, 16) => {
+                let data = image
+                    .into_luma16()
+                    .into_raw()
+                    .into_iter()
+                    .flat_map(u16::to_le_bytes)
+                    .collect();
+                (data, "uint16", 1_u32, "MONOCHROME2".to_string())
+            }
+            (3, 24) => (
+                image.into_rgb8().into_raw(),
+                "uint8",
+                3_u32,
+                "RGB".to_string(),
+            ),
+            _ => {
+                return Err(js_error(
+                    CODE_UNSUPPORTED_IMAGE_LAYOUT,
+                    format!("unsupported derived display frame color type: {color:?}"),
+                ));
+            }
         };
 
     Ok(NodeRenderedFrame {

--- a/bindings/node/test/api.test.mjs
+++ b/bindings/node/test/api.test.mjs
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
-import { prepareDicom, renderFrame } from '../index.js'
+import { prepareDicom, renderDisplayFrame, renderFrame } from '../index.js'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const DEFAULT_FIXTURES = {
@@ -23,6 +23,11 @@ function requireFixture(name) {
   throw new Error(`${name} environment variable is required, or run make test-node to download fixtures`)
 }
 
+function frameByteLength(rendered) {
+  const bytesPerSample = rendered.dtype.endsWith('8') ? 1 : 2
+  return rendered.width * rendered.height * rendered.samplesPerPixel * bytesPerSample
+}
+
 test('prepareDicom accepts a file path and renders raw monochrome pixels', () => {
   const prepared = prepareDicom({ path: requireFixture('DICOM_PREPROCESSING_CT_FIXTURE') })
   const rendered = prepared.renderFrame(0)
@@ -34,10 +39,7 @@ test('prepareDicom accepts a file path and renders raw monochrome pixels', () =>
   assert.equal(rendered.photometricInterpretation.startsWith('MONOCHROME'), true)
   assert.match(rendered.dtype, /^u?int(8|16)$/)
   assert.equal(Buffer.isBuffer(rendered.data), true)
-  assert.equal(
-    rendered.data.length,
-    rendered.width * rendered.height * rendered.samplesPerPixel * (rendered.dtype === 'uint8' ? 1 : 2),
-  )
+  assert.equal(rendered.data.length, frameByteLength(rendered))
 })
 
 test('prepareDicom accepts bytes with parity against path input', () => {
@@ -78,6 +80,16 @@ test('renderFrame returns RGB metadata for RGB DICOM input', () => {
   assert.equal(rendered.data.length, rendered.width * rendered.height * rendered.samplesPerPixel)
 })
 
+test('renderDisplayFrame matches raw rendering for stored display frames', () => {
+  const prepared = prepareDicom({ path: requireFixture('DICOM_PREPROCESSING_CT_FIXTURE') })
+  const raw = renderFrame(prepared, 0)
+  const display = renderDisplayFrame(prepared, 0)
+  const displayMethod = prepared.renderDisplayFrame(0)
+
+  assert.deepEqual(display, raw)
+  assert.deepEqual(displayMethod, raw)
+})
+
 test('derived frame sources are exposed and raw rendering rejects them', () => {
   const prepared = prepareDicom(
     { path: requireFixture('DICOM_PREPROCESSING_MULTIFRAME_FIXTURE') },
@@ -88,10 +100,50 @@ test('derived frame sources are exposed and raw rendering rejects them', () => {
   assert.throws(() => prepared.renderFrame(0), { code: 'DERIVED_FRAME_NO_RAW_SOURCE' })
 })
 
+test('renderDisplayFrame renders derived laplacian mip output', () => {
+  const prepared = prepareDicom(
+    { path: requireFixture('DICOM_PREPROCESSING_MULTIFRAME_FIXTURE') },
+    { volumeHandler: { kind: 'laplacian-mip', skipStart: 0, skipEnd: 0 } },
+  )
+
+  assert.deepEqual(prepared.framePlan.displayFrames, [{ kind: 'derived' }])
+  assert.throws(() => prepared.renderFrame(0), { code: 'DERIVED_FRAME_NO_RAW_SOURCE' })
+
+  const rendered = prepared.renderDisplayFrame(0)
+  const topLevelRendered = renderDisplayFrame(prepared, 0)
+
+  assert.equal(rendered.displayFrameIndex, 0)
+  assert.deepEqual(rendered.source, { kind: 'derived' })
+  assert.equal(Buffer.isBuffer(rendered.data), true)
+  assert.equal(rendered.dtype, 'uint16')
+  assert.equal(rendered.samplesPerPixel, 1)
+  assert.equal(rendered.photometricInterpretation, 'MONOCHROME2')
+  assert.equal(rendered.rescaleSlope, 1)
+  assert.equal(rendered.rescaleIntercept, 0)
+  assert.equal(rendered.windowCenter, undefined)
+  assert.equal(rendered.windowWidth, undefined)
+  assert.equal(rendered.data.length, frameByteLength(rendered))
+  assert.deepEqual(topLevelRendered, rendered)
+})
+
+test('renderDisplayFrame has path and byte parity for derived frames', () => {
+  const path = requireFixture('DICOM_PREPROCESSING_MULTIFRAME_FIXTURE')
+  const options = { volumeHandler: { kind: 'laplacian-mip', skipStart: 0, skipEnd: 0 } }
+  const fromPath = renderDisplayFrame(prepareDicom({ path }, options), 0)
+  const fromBytes = renderDisplayFrame(prepareDicom({ bytes: readFileSync(path), filename: 'emri_small.dcm' }, options), 0)
+
+  assert.equal(fromBytes.width, fromPath.width)
+  assert.equal(fromBytes.height, fromPath.height)
+  assert.equal(fromBytes.dtype, fromPath.dtype)
+  assert.deepEqual(fromBytes.source, fromPath.source)
+  assert.deepEqual(fromBytes.data, fromPath.data)
+})
+
 test('invalid frame index is structured', () => {
   const prepared = prepareDicom({ path: requireFixture('DICOM_PREPROCESSING_CT_FIXTURE') })
 
   assert.throws(() => renderFrame(prepared, 999), { code: 'FRAME_INDEX_OUT_OF_RANGE' })
+  assert.throws(() => renderDisplayFrame(prepared, 999), { code: 'FRAME_INDEX_OUT_OF_RANGE' })
 })
 
 test('frame indexes are validated before rendering', () => {
@@ -99,6 +151,8 @@ test('frame indexes are validated before rendering', () => {
 
   assert.throws(() => prepared.renderFrame(0.5), { code: 'FRAME_INDEX_OUT_OF_RANGE' })
   assert.throws(() => renderFrame(prepared, 2 ** 40), { code: 'FRAME_INDEX_OUT_OF_RANGE' })
+  assert.throws(() => prepared.renderDisplayFrame(0.5), { code: 'FRAME_INDEX_OUT_OF_RANGE' })
+  assert.throws(() => renderDisplayFrame(prepared, 2 ** 40), { code: 'FRAME_INDEX_OUT_OF_RANGE' })
 })
 
 test('unreadable path and non-DICOM bytes are structured', () => {

--- a/bindings/node/test/typecheck.ts
+++ b/bindings/node/test/typecheck.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import {
   PreparedDicom,
   prepareDicom,
+  renderDisplayFrame,
   renderFrame,
   type DicomInput,
   type FrameSource,
@@ -16,6 +17,7 @@ const handler: VolumeHandler = { kind: 'max-intensity', skipStart: 1, skipEnd: 1
 const prepared: PreparedDicom = prepareDicom(input, { volumeHandler: handler })
 const source: FrameSource = prepared.framePlan.displayFrames[0]
 const rendered: RenderedFrame = renderFrame(prepared, 0)
+const displayRendered: RenderedFrame = renderDisplayFrame(prepared, 0)
 const dtype: RenderedFrame['dtype'] = 'int8'
 
 if (source.kind === 'stored') {
@@ -23,5 +25,7 @@ if (source.kind === 'stored') {
 }
 
 rendered.data.byteLength.toFixed()
+displayRendered.data.byteLength.toFixed()
 prepareDicom(byteViewInput).renderFrame(0)
+prepareDicom(byteViewInput).renderDisplayFrame(0)
 dtype.toUpperCase()


### PR DESCRIPTION
## Motivation
Electron viewer integration needs a Node path that can render display frames produced by volume handlers. The existing raw `renderFrame` API correctly rejects derived display frames, but DBT-style display plans using handlers such as `laplacian-mip` need a separate way to retrieve the synthesized pixels.

Closes #88

## Solution
Add `renderDisplayFrame` as both a `PreparedDicom` method and top-level function. Stored display frames delegate to the existing raw renderer, while derived display frames use the Rust `ViewerDicom::decode_display_frame_with_options` path and return viewer-safe `RenderedFrame` metadata plus a Node `Buffer`.

## Changes
- Expose `PreparedDicom.renderDisplayFrame(frameIndex)` and `renderDisplayFrame(prepared, frameIndex)` in the Node/NAPI binding and generated TypeScript declarations.
- Preserve `renderFrame` as the raw stored-frame API, including `DERIVED_FRAME_NO_RAW_SOURCE` for derived-only frames.
- Convert derived `Luma8`, `Luma16`, and `Rgb8` display images into `RenderedFrame` buffers with stable metadata.
- Document the raw-versus-display render split in the README Node section.

## Test plan
- [x] Confirmed the new Node API test failed before implementation with missing `renderDisplayFrame` export.
- [x] Targeted Node API test: `DICOM_PREPROCESSING_CT_FIXTURE="$PWD/target/dicom_test_files/pydicom/CT_small.dcm" DICOM_PREPROCESSING_MULTIFRAME_FIXTURE="$PWD/target/dicom_test_files/pydicom/emri_small.dcm" DICOM_PREPROCESSING_RGB_FIXTURE="$PWD/target/dicom_test_files/pydicom/SC_rgb.dcm" node --test bindings/node/test/api.test.mjs`
- [x] `cargo test -p dicom-preprocessing-node`
- [x] `make quality-node`
- [x] `make test-node`
- [x] `make init-no-project` then `make quality`
- [x] `make test`
- [x] `git diff --check`

## Test suite changes (Required when test coverage changed)
- [x] Added Node API coverage for derived `laplacian-mip` display rendering, stored-frame parity, path/byte parity, invalid indexes, and TypeScript usage.
- [x] No tests were removed.
- [x] Existing raw derived-frame rejection coverage remains in place.

Generated with Codex.