### PR TITLE
Honor requested voxel spacing

### DIFF
--- a/src/metadata/resolution.rs
+++ b/src/metadata/resolution.rs
@@ -104,6 +104,14 @@ impl Resolution {
         }
     }
 
+    pub fn scale_xy(&self, scale_x: f32, scale_y: f32) -> Self {
+        Resolution {
+            pixels_per_mm_x: self.pixels_per_mm_x * scale_x,
+            pixels_per_mm_y: self.pixels_per_mm_y * scale_y,
+            frames_per_mm: self.frames_per_mm,
+        }
+    }
+
     pub fn with_frames_per_mm(mut self, frames_per_mm: f32) -> Self {
         self.frames_per_mm = Some(frames_per_mm);
         self

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -132,7 +132,11 @@ impl Preprocessor {
 
         target_size.map(|(target_width, target_height)| {
             let first_image = images.first().unwrap();
-            Resize::new(first_image, target_width, target_height, self.filter)
+            if self.size.is_none() && self.spacing.is_some() && resolution.is_some() {
+                Resize::new_exact(first_image, target_width, target_height, self.filter)
+            } else {
+                Resize::new(first_image, target_width, target_height, self.filter)
+            }
         })
     }
 
@@ -170,17 +174,34 @@ impl Preprocessor {
                 if spacing_config.spacing_mm_z.is_some() && res.frames_per_mm.is_some() =>
             {
                 let target_spacing_mm_z = spacing_config.spacing_mm_z.unwrap();
-                let target_frames_per_mm = 1.0 / target_spacing_mm_z;
                 let current_frames_per_mm = res.frames_per_mm.unwrap();
-
-                // Scale factor for frames
-                let scale_z = target_frames_per_mm / current_frames_per_mm;
-
-                // Compute target frame count based on actual current frame count
-                Some((current_frame_count as f32 * scale_z).round() as u32)
+                let source_extent_mm =
+                    current_frame_count.saturating_sub(1) as f32 / current_frames_per_mm;
+                Some((source_extent_mm / target_spacing_mm_z).round() as u32 + 1)
             }
             _ => None,
         }
+    }
+
+    fn update_z_resolution_after_resampling(
+        resolution: &mut Option<Resolution>,
+        source_frame_count: usize,
+        output_frame_count: usize,
+    ) {
+        let Some(resolution) = resolution.as_mut() else {
+            return;
+        };
+        let Some(source_frames_per_mm) = resolution.frames_per_mm else {
+            return;
+        };
+        if source_frame_count <= 1 || output_frame_count <= 1 {
+            return;
+        }
+
+        resolution.frames_per_mm = Some(
+            source_frames_per_mm * (output_frame_count - 1) as f32
+                / (source_frame_count - 1) as f32,
+        );
     }
 
     /// Apply z-direction interpolation to resample frames based on spacing
@@ -299,17 +320,13 @@ impl Preprocessor {
         if let Some(target_frames) = target_frames {
             let original_frame_count = image_data.len();
             image_data = self.interpolate_z_spacing(image_data, target_frames);
+            Self::update_z_resolution_after_resampling(
+                &mut resolution,
+                original_frame_count,
+                image_data.len(),
+            );
             if image_data.len() != original_frame_count {
                 frame_plan.display_frames = vec![VolumeFrameSource::Derived; image_data.len()];
-            }
-
-            // Update the z-resolution after interpolation
-            if let Some(ref mut res) = resolution {
-                if let Some(spacing_config) = self.spacing {
-                    if let Some(target_spacing_mm_z) = spacing_config.spacing_mm_z {
-                        res.frames_per_mm = Some(1.0 / target_spacing_mm_z);
-                    }
-                }
             }
         }
 
@@ -382,16 +399,13 @@ impl Preprocessor {
             .or_else(|| self.volume_handler.get_target_frames());
 
         if let Some(target_frames) = target_frames {
+            let original_frame_count = combined_volume.len();
             combined_volume = self.interpolate_z_spacing(combined_volume, target_frames);
-
-            // Update the z-resolution after interpolation
-            if let Some(ref mut res) = resolution {
-                if let Some(spacing_config) = self.spacing {
-                    if let Some(target_spacing_mm_z) = spacing_config.spacing_mm_z {
-                        res.frames_per_mm = Some(1.0 / target_spacing_mm_z);
-                    }
-                }
-            }
+            Self::update_z_resolution_after_resampling(
+                &mut resolution,
+                original_frame_count,
+                combined_volume.len(),
+            );
         }
 
         // Use the combined volume for determining common crop bounds
@@ -992,6 +1006,7 @@ mod tests {
     #[case("pydicom/CT_small.dcm", 1.0, 1.0)]
     #[case("pydicom/CT_small.dcm", 0.5, 0.5)]
     #[case("pydicom/CT_small.dcm", 2.0, 2.0)]
+    #[case("pydicom/CT_small.dcm", 1.0, 0.5)]
     fn test_spacing_based_resize(
         #[case] dicom_file_path: &str,
         #[case] target_spacing_x: f32,
@@ -1053,6 +1068,15 @@ mod tests {
         let output_resolution = metadata.resolution.unwrap();
         let output_spacing_x = 1.0 / output_resolution.pixels_per_mm_x;
         let output_spacing_y = 1.0 / output_resolution.pixels_per_mm_y;
+        let realized_spacing_x = native_spacing_x * native_width as f32 / output_width as f32;
+        let realized_spacing_y = native_spacing_y * native_height as f32 / output_height as f32;
+
+        assert!((output_spacing_x - realized_spacing_x).abs() < f32::EPSILON);
+        assert!((output_spacing_y - realized_spacing_y).abs() < f32::EPSILON);
+        assert_eq!(
+            output_resolution.frames_per_mm,
+            native_resolution.frames_per_mm
+        );
 
         // Allow small floating point error (tolerance is higher for larger spacing values)
         let tolerance = target_spacing_x.max(target_spacing_y) * 0.02; // 2% tolerance
@@ -1244,8 +1268,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case("pydicom/emri_small.dcm", 10.0)] // Upsample: larger spacing = fewer frames
-    #[case("pydicom/emri_small.dcm", 2.5)] // Downsample: smaller spacing = more frames
+    #[case("pydicom/emri_small.dcm", 10.0)]
+    #[case("pydicom/emri_small.dcm", 4.0)]
+    #[case("pydicom/emri_small.dcm", 2.5)]
     fn test_spacing_based_z_resize(#[case] dicom_file_path: &str, #[case] target_spacing_z: f32) {
         let mut dicom_file = open_file(dicom_test_files::path(dicom_file_path).unwrap()).unwrap();
 
@@ -1293,8 +1318,8 @@ mod tests {
         let (images, metadata) = preprocessor.prepare_image(&dicom_file, false).unwrap();
 
         // Check that the output frame count matches expected scaling
-        let expected_frame_count =
-            (native_frame_count as f32 * (native_spacing_z / target_spacing_z)).round() as usize;
+        let native_extent_z = (native_frame_count - 1) as f32 * native_spacing_z;
+        let expected_frame_count = (native_extent_z / target_spacing_z).round() as usize + 1;
 
         assert_eq!(
             images.len(),
@@ -1309,11 +1334,16 @@ mod tests {
             .map(|f| 1.0 / f)
             .expect("Should have output z-spacing");
 
-        // Allow small floating point error
-        let tolerance = target_spacing_z * 0.05; // 5% tolerance
+        let expected_output_spacing_z = native_extent_z / (expected_frame_count - 1) as f32;
+        let output_extent_z = (images.len() - 1) as f32 * output_spacing_z;
+        let tolerance = f32::EPSILON * native_extent_z;
         assert!(
-            (output_spacing_z - target_spacing_z).abs() < tolerance,
-            "Output spacing Z should be close to target. Got {output_spacing_z} expected {target_spacing_z}"
+            (output_spacing_z - expected_output_spacing_z).abs() < tolerance,
+            "Output spacing Z should describe the realized sampling. Got {output_spacing_z} expected {expected_output_spacing_z}"
+        );
+        assert!(
+            (output_extent_z - native_extent_z).abs() < tolerance,
+            "Output extent Z should preserve source endpoints. Got {output_extent_z} expected {native_extent_z}"
         );
     }
 

--- a/src/transform/resize.rs
+++ b/src/transform/resize.rs
@@ -91,13 +91,27 @@ impl Resize {
             filter,
         }
     }
+
+    pub fn new_exact(
+        image: &DynamicImage,
+        target_width: u32,
+        target_height: u32,
+        filter: FilterType,
+    ) -> Self {
+        let (width, height) = image.dimensions();
+        Resize {
+            scale_x: target_width as f32 / width as f32,
+            scale_y: target_height as f32 / height as f32,
+            filter,
+        }
+    }
 }
 
 impl Transform<DynamicImage> for Resize {
     fn apply(&self, image: &DynamicImage) -> DynamicImage {
         let (width, height) = image.dimensions();
-        let target_width = (width as f32 * self.scale_x) as u32;
-        let target_height = (height as f32 * self.scale_y) as u32;
+        let target_width = (width as f32 * self.scale_x).round() as u32;
+        let target_height = (height as f32 * self.scale_y).round() as u32;
 
         // Special handling for MaxPool
         if self.filter == FilterType::MaxPool {
@@ -124,27 +138,20 @@ impl Transform<DynamicImage> for Resize {
             }
             output
         } else {
-            image.resize(target_width, target_height, self.filter.into())
+            image.resize_exact(target_width, target_height, self.filter.into())
         }
     }
 }
 
 impl Transform<Resolution> for Resize {
     fn apply(&self, resolution: &Resolution) -> Resolution {
-        assert_eq!(
-            self.scale_x, self.scale_y,
-            "Expected scale_x and scale_y to be equal: {} {}",
-            self.scale_x, self.scale_y
-        );
-        let scale = self.scale_x;
-        resolution.scale(scale)
+        resolution.scale_xy(self.scale_x, self.scale_y)
     }
 }
 
 impl InvertibleTransform<Resolution> for Resize {
     fn invert(&self, resolution: &Resolution) -> Resolution {
-        let scale = 1.0 / self.scale_x;
-        resolution.scale(scale)
+        resolution.scale_xy(1.0 / self.scale_x, 1.0 / self.scale_y)
     }
 }
 
@@ -291,6 +298,15 @@ mod tests {
         assert_eq!(resize.apply(&dynamic_image), expected_dynamic_image);
     }
 
+    #[test]
+    fn fixed_size_resize_preserves_aspect_ratio() {
+        let image = DynamicImage::ImageRgba8(RgbaImage::new(8, 4));
+
+        let resize = Resize::new(&image, 4, 4, FilterType::Nearest);
+
+        assert_eq!(resize.apply(&image).dimensions(), (4, 2));
+    }
+
     #[rstest]
     #[case(Resize { scale_x: 2.0, scale_y: 2.0, filter: FilterType::Nearest })]
     fn test_write_tags(#[case] resize: Resize) {
@@ -380,6 +396,21 @@ mod tests {
     ) {
         let result = resize.apply(&resolution);
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn anisotropic_resize_updates_only_in_plane_resolution() {
+        let resize = Resize {
+            scale_x: 0.5,
+            scale_y: 2.0,
+            filter: FilterType::Nearest,
+        };
+        let resolution = Resolution::new_3d(2.0, 4.0, 0.25);
+
+        assert_eq!(
+            resize.apply(&resolution),
+            Resolution::new_3d(1.0, 8.0, 0.25)
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## Motivation

Spacing-based preprocessing used the fixed-size aspect-fit resize path, so different x/y spacing requests collapsed to one scale. Z resampling scaled the number of frames rather than the intervals between frame centers, and in-plane resizing also changed `frames_per_mm`.

## Solution

Use independent x/y scales only for physical-spacing requests while retaining aspect-fit behavior for fixed-size requests. Compute z output counts from the source endpoint extent, then report the spacing realized by the integer output dimensions and frame count.

## Changes

- Add an exact-dimension resize constructor for anisotropic spacing-based resampling.
- Keep `Resize::new` as the aspect-fit path for fixed output sizes.
- Update only x/y resolution during in-plane resize and preserve `frames_per_mm`.
- Compute z counts as `round((N - 1) * source_spacing / target_spacing) + 1`.
- Derive output z resolution from the realized frame count so first-to-last extent is preserved.
- Add regressions for anisotropic x/y spacing, fixed-size aspect fit, integer and non-integer z ratios, endpoint extent, and output metadata.

## Test plan

- `cargo test spacing_based --all-features`
- `cargo test transform::resize::tests --all-features`
- `make quality`
- `make test`

Fixes #91

Generated with Codex.