### PR TITLE
Correct U16 to U8 TIFF scaling

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -78,13 +78,19 @@ impl LoadFromTiff<u8> for Array4<u8> {
     fn to_vec(decoded: DecodingResult) -> Result<Vec<u8>, TiffError> {
         match decoded {
             DecodingResult::U8(image) => Ok(image),
-            DecodingResult::U16(image) => Ok(image
-                .iter()
-                .map(|&x| (x as u8) * (u8::MAX / u16::MAX as u8))
-                .collect()),
+            DecodingResult::U16(image) => Ok(image.into_iter().map(scale_u16_to_u8).collect()),
             _ => Err(TiffError::UnsupportedDataType { data_type: decoded }),
         }
     }
+}
+
+/// Scale the full `u16` range into `u8`, rounding to the nearest output value.
+fn scale_u16_to_u8(value: u16) -> u8 {
+    let input_max = u32::from(u16::MAX);
+    let output_max = u32::from(u8::MAX);
+    let rounding_offset = input_max / 2;
+    let scaled = (u32::from(value) * output_max + rounding_offset) / input_max;
+    u8::try_from(scaled).expect("scaled u16 value must fit in u8")
 }
 
 impl LoadFromTiff<u16> for Array4<u16> {
@@ -256,6 +262,15 @@ mod tests {
 
     const NUM_CHANNELS_MONO: usize = 1;
     const NUM_CHANNELS_RGB: usize = 3;
+
+    #[test]
+    fn u16_to_u8_scales_the_full_range_with_nearest_rounding() {
+        let decoded = DecodingResult::U16(vec![0, 128, 129, 257, 32_767, 32_768, u16::MAX]);
+
+        let converted = Array4::<u8>::to_vec(decoded).unwrap();
+
+        assert_eq!(converted, vec![0, 0, 1, 1, 127, 128, u8::MAX]);
+    }
 
     #[rstest]
     #[case("pydicom/CT_small.dcm", 16, false, false)]

--- a/tests/test_load_tiff.py
+++ b/tests/test_load_tiff.py
@@ -150,6 +150,16 @@ def test_load_tiff_u8(path):
     assert np.array_equal(result, array)
 
 
+def test_load_tiff_u8_scales_u16_with_nearest_rounding(path):
+    array = np.array([0, 128, 129, 257, 32767, 32768, 65535], dtype=np.uint16).reshape(1, 1, 7, 1)
+    Image.fromarray(array[0, ..., 0]).save(path, format="TIFF")
+
+    result = load_tiff_u8(path)
+
+    expected = np.array([0, 0, 1, 1, 127, 128, 255], dtype=np.uint8).reshape(1, 1, 7, 1)
+    assert np.array_equal(result, expected)
+
+
 def test_load_tiff_u16(path):
     N, H, W, C = 3, 10, 10, 1
     array = np.random.randint(0, 65535, size=(N, H, W, C), dtype=np.uint16)


### PR DESCRIPTION
## Motivation

The U16-to-U8 TIFF loader narrowed each sample to `u8` before applying its scale factor. Values therefore wrapped to their low byte, so a 16-bit midpoint decoded as zero instead of 128.

Fixes #94

## Solution

Scale in `u32` across the complete input and output ranges, adding half the input range before division to define round-to-nearest behavior. Existing U8 passthrough and U8-to-U16 conversions are unchanged.

## Changes

- add a dedicated U16-to-U8 full-range scaling helper
- document and implement nearest-value rounding
- add Rust coverage for endpoints, rounding thresholds, and the midpoint
- add Python integration coverage through `load_tiff_u8` with a real 16-bit TIFF

## Test plan

- [x] Confirm both new regressions fail before the production change
- [x] `cargo test u16_to_u8_scales_the_full_range_with_nearest_rounding --all-features`
- [x] `pytest tests/test_load_tiff.py::test_load_tiff_u8_scales_u16_with_nearest_rounding`
- [x] `make quality`
- [x] `make test`

Generated with Codex.