### PR TITLE
Validate preprocessing inputs before use

### DIFF
--- a/src/errors/dicom.rs
+++ b/src/errors/dicom.rs
@@ -32,6 +32,12 @@ pub enum DicomError {
     #[snafu(display("invalid DICOM property value '{}': {}", name, value))]
     InvalidValueError { name: &'static str, value: String },
 
+    #[snafu(display("invalid preprocessor configuration '{}': {}", field, reason))]
+    InvalidPreprocessorConfiguration {
+        field: &'static str,
+        reason: &'static str,
+    },
+
     #[snafu(display("error processing DICOM pixel data: {:?}", source))]
     PixelDataError {
         #[snafu(source(from(dicom::pixeldata::Error, Box::new)))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ pub enum Error {
     #[snafu(display("Invalid output path: {}", path.display()))]
     InvalidOutputPath { path: PathBuf },
 
+    #[snafu(display("Invalid preprocessing configuration: {}", source))]
+    InvalidConfiguration { source: DicomError },
+
     #[snafu(display("Failed to create directory: {}", path.display()))]
     CreateDir {
         path: PathBuf,
@@ -145,8 +148,8 @@ struct Args {
         short = 'b',
         value_parser = clap::builder::ValueParser::new(|s: &str| {
             let value = s.parse::<f32>().map_err(|_| clap::Error::raw(ErrorKind::InvalidValue, "Invalid border fraction"))?;
-            if value < 0.0 || value > 0.5 {
-                Err(clap::Error::raw(ErrorKind::InvalidValue, "Border fraction must be between 0.0 and 0.5"))
+            if !value.is_finite() || !(0.0..=0.5).contains(&value) {
+                Err(clap::Error::raw(ErrorKind::InvalidValue, "Border fraction must be finite and between 0.0 and 0.5"))
             } else {
                 Ok(value)
             }
@@ -164,7 +167,11 @@ struct Args {
             if parts.len() == 2 {
                 let width = parts[0].parse::<u32>().map_err(|_| clap::Error::raw(ErrorKind::InvalidValue, "Invalid width"))?;
                 let height = parts[1].parse::<u32>().map_err(|_| clap::Error::raw(ErrorKind::InvalidValue, "Invalid height"))?;
-                Ok((width, height))
+                if width == 0 || height == 0 {
+                    Err(clap::Error::raw(ErrorKind::InvalidValue, "Width and height must be at least 1"))
+                } else {
+                    Ok((width, height))
+                }
             } else {
                 Err(clap::Error::raw(ErrorKind::InvalidValue, "Size must be in the format width,height"))
             }
@@ -178,14 +185,27 @@ struct Args {
         conflicts_with = "size",
         value_parser = clap::builder::ValueParser::new(|s: &str| {
             let parts: Vec<&str> = s.split(',').collect();
+            let parse_spacing = |value: &str, name: &'static str| {
+                let value = value.parse::<f32>().map_err(|_| {
+                    clap::Error::raw(ErrorKind::InvalidValue, format!("Invalid {name} spacing"))
+                })?;
+                if !value.is_finite() || value <= 0.0 {
+                    Err(clap::Error::raw(
+                        ErrorKind::InvalidValue,
+                        format!("{name} spacing must be finite and greater than 0"),
+                    ))
+                } else {
+                    Ok(value)
+                }
+            };
             if parts.len() == 2 {
-                let x = parts[0].parse::<f32>().map_err(|_| clap::Error::raw(ErrorKind::InvalidValue, "Invalid x spacing"))?;
-                let y = parts[1].parse::<f32>().map_err(|_| clap::Error::raw(ErrorKind::InvalidValue, "Invalid y spacing"))?;
+                let x = parse_spacing(parts[0], "x")?;
+                let y = parse_spacing(parts[1], "y")?;
                 Ok((x, y, None))
             } else if parts.len() == 3 {
-                let x = parts[0].parse::<f32>().map_err(|_| clap::Error::raw(ErrorKind::InvalidValue, "Invalid x spacing"))?;
-                let y = parts[1].parse::<f32>().map_err(|_| clap::Error::raw(ErrorKind::InvalidValue, "Invalid y spacing"))?;
-                let z = parts[2].parse::<f32>().map_err(|_| clap::Error::raw(ErrorKind::InvalidValue, "Invalid z spacing"))?;
+                let x = parse_spacing(parts[0], "x")?;
+                let y = parse_spacing(parts[1], "y")?;
+                let z = parse_spacing(parts[2], "z")?;
                 Ok((x, y, Some(z)))
             } else {
                 Err(clap::Error::raw(ErrorKind::InvalidValue, "Spacing must be in the format x,y or x,y,z"))
@@ -239,6 +259,7 @@ struct Args {
         short = 't',
         default_value_t = DEFAULT_INTERPOLATE_TARGET_FRAMES,
         requires = "volume_handler",
+        value_parser = clap::value_parser!(u32).range(1..),
     )]
     target_frames: u32,
 
@@ -524,6 +545,9 @@ fn run(args: Args) -> Result<(), Error> {
         target_frames: args.target_frames,
         convert_options,
     };
+    preprocessor
+        .validate()
+        .map_err(|source| Error::InvalidConfiguration { source })?;
     let compressor = args.compressor;
 
     // Create progress bar
@@ -587,6 +611,7 @@ mod tests {
     use crate::FilterType;
     use crate::PaddingDirection;
     use crate::SupportedCompressor;
+    use clap::{error::ErrorKind, Parser};
     use dicom::dictionary_std::tags;
     use dicom::object::open_file;
     use dicom_preprocessing::crop::{DEFAULT_CROP_ORIGIN, DEFAULT_CROP_SIZE};
@@ -601,6 +626,24 @@ mod tests {
 
     use tiff::tags::ResolutionUnit;
     use tiff::tags::Tag;
+
+    #[rstest]
+    #[case(&["--size", "0,32"])]
+    #[case(&["--size", "32,0"])]
+    #[case(&["--spacing", "0,1"])]
+    #[case(&["--spacing", "1,nan"])]
+    #[case(&["--spacing", "1,1,inf"])]
+    #[case(&["--volume-handler", "interpolate", "--target-frames", "0"])]
+    #[case(&["--border-frac", "nan"])]
+    fn invalid_preprocessing_arguments_are_rejected(#[case] options: &[&str]) {
+        let args = ["dicom-preprocess", "source.dcm", "output.tiff"]
+            .into_iter()
+            .chain(options.iter().copied());
+
+        let error = Args::try_parse_from(args).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
 
     #[rstest]
     #[case("path")]

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -87,6 +87,67 @@ impl Default for Preprocessor {
 impl Preprocessor {
     const PARALLEL_TRANSFORM_MIN_FRAMES: usize = 2;
 
+    /// Validate configuration values before decoding or allocating image buffers.
+    pub fn validate(&self) -> Result<(), DicomError> {
+        if self.size.is_some() && self.spacing.is_some() {
+            return Err(DicomError::InvalidPreprocessorConfiguration {
+                field: "size/spacing",
+                reason: "size and spacing are mutually exclusive",
+            });
+        }
+
+        if let Some((width, height)) = self.size {
+            if width == 0 || height == 0 {
+                return Err(DicomError::InvalidPreprocessorConfiguration {
+                    field: "size",
+                    reason: "width and height must be at least 1",
+                });
+            }
+        }
+
+        if let Some(spacing) = self.spacing {
+            Self::validate_spacing("spacing_mm_x", spacing.spacing_mm_x)?;
+            Self::validate_spacing("spacing_mm_y", spacing.spacing_mm_y)?;
+            if let Some(spacing_mm_z) = spacing.spacing_mm_z {
+                Self::validate_spacing("spacing_mm_z", spacing_mm_z)?;
+            }
+        }
+
+        if self.target_frames == 0 {
+            return Err(DicomError::InvalidPreprocessorConfiguration {
+                field: "target_frames",
+                reason: "target frame count must be at least 1",
+            });
+        }
+        if self.volume_handler.get_target_frames() == Some(0) {
+            return Err(DicomError::InvalidPreprocessorConfiguration {
+                field: "volume_handler.target_frames",
+                reason: "target frame count must be at least 1",
+            });
+        }
+
+        if let Some(border_frac) = self.border_frac {
+            if !border_frac.is_finite() || !(0.0..=0.5).contains(&border_frac) {
+                return Err(DicomError::InvalidPreprocessorConfiguration {
+                    field: "border_frac",
+                    reason: "border fraction must be finite and between 0.0 and 0.5",
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_spacing(field: &'static str, value: f32) -> Result<(), DicomError> {
+        if !value.is_finite() || value <= 0.0 {
+            return Err(DicomError::InvalidPreprocessorConfiguration {
+                field,
+                reason: "spacing must be finite and greater than 0",
+            });
+        }
+        Ok(())
+    }
+
     fn get_crop(&self, images: &[DynamicImage]) -> Option<Crop> {
         match self.crop {
             true => Some(Crop::new_from_images(
@@ -254,6 +315,12 @@ impl Preprocessor {
         parallel: bool,
     ) -> Result<PreparedVolume, DicomError> {
         let frame_count: u32 = FrameCount::try_from(file)?.into();
+        if frame_count == 0 {
+            return Err(DicomError::InvalidValueError {
+                name: "Number of Frames",
+                value: frame_count.to_string(),
+            });
+        }
         let effective_handler = if frame_count == 1 {
             VolumeHandler::Keep(KeepVolume)
         } else {
@@ -281,6 +348,8 @@ impl Preprocessor {
         file: &FileDicomObject<InMemDicomObject>,
         parallel: bool,
     ) -> Result<(Vec<DynamicImage>, PreprocessingMetadata, VolumeFramePlan), DicomError> {
+        self.validate()?;
+
         // Run decoding and volume handling
         let prepared_volume = self.prepare_volume_with_single_frame_guard(file, parallel)?;
         let mut image_data = prepared_volume.images;
@@ -355,6 +424,8 @@ impl Preprocessor {
         files: &[FileDicomObject<InMemDicomObject>],
         parallel: bool,
     ) -> Result<(Vec<Vec<DynamicImage>>, PreprocessingMetadata), DicomError> {
+        self.validate()?;
+
         if files.is_empty() {
             return Err(DicomError::Other {
                 message: "Cannot process empty batch of files".to_string(),
@@ -452,6 +523,8 @@ impl Preprocessor {
         &self,
         images: &[DynamicImage],
     ) -> Result<(Vec<DynamicImage>, PreprocessingMetadata), DicomError> {
+        self.validate()?;
+
         // Try to determine the resolution (none for test images)
         let resolution = None;
 
@@ -546,6 +619,99 @@ mod tests {
             patient_orientation,
         );
         dicom
+    }
+
+    #[test]
+    fn central_slice_rejects_zero_frame_dicom_without_panicking() {
+        let mut dicom = open_file(dicom_test_files::path(MULTI_FRAME_TEST_DICOM).unwrap()).unwrap();
+        put_str_element(&mut dicom, tags::NUMBER_OF_FRAMES, VR::IS, "0");
+        let preprocessor = Preprocessor {
+            volume_handler: VolumeHandler::CentralSlice(CentralSlice),
+            ..Preprocessor::default()
+        };
+
+        let error = preprocessor.prepare_image(&dicom, false).unwrap_err();
+
+        assert!(matches!(
+            error,
+            DicomError::InvalidValueError {
+                name: "Number of Frames",
+                value,
+            } if value == "0"
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_preprocessor_configuration() {
+        let invalid_cases = [
+            (
+                Preprocessor {
+                    size: Some((0, 32)),
+                    ..Preprocessor::default()
+                },
+                "size",
+            ),
+            (
+                Preprocessor {
+                    spacing: Some(SpacingConfig::new(f32::NAN, 1.0)),
+                    ..Preprocessor::default()
+                },
+                "spacing_mm_x",
+            ),
+            (
+                Preprocessor {
+                    border_frac: Some(f32::INFINITY),
+                    ..Preprocessor::default()
+                },
+                "border_frac",
+            ),
+            (
+                Preprocessor {
+                    target_frames: 0,
+                    ..Preprocessor::default()
+                },
+                "target_frames",
+            ),
+            (
+                Preprocessor {
+                    volume_handler: VolumeHandler::Interpolate(InterpolateVolume::new(0)),
+                    ..Preprocessor::default()
+                },
+                "volume_handler.target_frames",
+            ),
+            (
+                Preprocessor {
+                    size: Some((32, 32)),
+                    spacing: Some(SpacingConfig::new(1.0, 1.0)),
+                    ..Preprocessor::default()
+                },
+                "size/spacing",
+            ),
+        ];
+
+        for (preprocessor, expected_field) in invalid_cases {
+            let error = preprocessor.validate().unwrap_err();
+            assert!(matches!(
+                error,
+                DicomError::InvalidPreprocessorConfiguration { field, .. }
+                    if field == expected_field
+            ));
+        }
+    }
+
+    #[test]
+    fn batch_preparation_validates_before_decoding() {
+        let preprocessor = Preprocessor {
+            size: Some((0, 32)),
+            ..Preprocessor::default()
+        };
+
+        let error = preprocessor.prepare_images_batch(&[], false).unwrap_err();
+
+        assert!(matches!(
+            error,
+            DicomError::InvalidPreprocessorConfiguration { field: "size", .. }
+        ));
     }
 
     fn assert_images_equal(expected: &[DynamicImage], actual: &[DynamicImage]) {
@@ -1178,25 +1344,20 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_frame_input_does_not_bypass_laplacian_mip() {
+    fn test_zero_frame_input_is_rejected_before_laplacian_mip() {
         let dicom_file = malformed_zero_frame_dicom();
         let preprocessor = laplacian_mip_preprocessor();
 
         let err = preprocessor
             .decode_with_single_frame_guard(&dicom_file, false)
             .unwrap_err();
-        match err {
-            DicomError::LaplacianMipInsufficientFrames {
-                number_of_frames,
-                skip_start,
-                skip_end,
-            } => {
-                assert_eq!(number_of_frames, 0);
-                assert_eq!(skip_start, 5);
-                assert_eq!(skip_end, 5);
-            }
-            other => panic!("Expected LaplacianMipInsufficientFrames, got {other}"),
-        }
+        assert!(matches!(
+            err,
+            DicomError::InvalidValueError {
+                name: "Number of Frames",
+                value,
+            } if value == "0"
+        ));
     }
 
     #[test]

--- a/src/python/preprocess.rs
+++ b/src/python/preprocess.rs
@@ -19,7 +19,7 @@ use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3::{
-    exceptions::{PyFileNotFoundError, PyRuntimeError},
+    exceptions::{PyFileNotFoundError, PyRuntimeError, PyValueError},
     pymodule,
     types::{PyAnyMethods, PyModule},
     Bound, PyAny, PyResult, Python,
@@ -141,22 +141,25 @@ impl PyPreprocessor {
             }
         });
 
-        Ok(Self {
-            inner: Preprocessor {
-                crop,
-                size,
-                spacing: spacing_config,
-                filter,
-                padding_direction,
-                crop_max,
-                volume_handler,
-                use_components,
-                use_padding,
-                border_frac,
-                target_frames,
-                convert_options,
-            },
-        })
+        let inner = Preprocessor {
+            crop,
+            size,
+            spacing: spacing_config,
+            filter,
+            padding_direction,
+            crop_max,
+            volume_handler,
+            use_components,
+            use_padding,
+            border_frac,
+            target_frames,
+            convert_options,
+        };
+        inner
+            .validate()
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+
+        Ok(Self { inner })
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -20,6 +20,28 @@ def test_preprocessor():
     assert isinstance(repr(preprocessor), str)
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "invalid_field"),
+    [
+        ({"size": (0, 32)}, "size"),
+        ({"size": (32, 0)}, "size"),
+        ({"spacing": (0.0, 1.0, None)}, "spacing_mm_x"),
+        ({"spacing": (-1.0, 1.0, None)}, "spacing_mm_x"),
+        ({"spacing": (float("nan"), 1.0, None)}, "spacing_mm_x"),
+        ({"spacing": (1.0, float("inf"), None)}, "spacing_mm_y"),
+        ({"spacing": (1.0, 1.0, 0.0)}, "spacing_mm_z"),
+        ({"target_frames": 0}, "target_frames"),
+        ({"border_frac": -0.1}, "border_frac"),
+        ({"border_frac": float("nan")}, "border_frac"),
+        ({"border_frac": 0.51}, "border_frac"),
+        ({"size": (32, 32), "spacing": (1.0, 1.0, None)}, "size/spacing"),
+    ],
+)
+def test_preprocessor_rejects_invalid_configuration(kwargs, invalid_field):
+    with pytest.raises(ValueError, match=invalid_field):
+        dp.Preprocessor(**kwargs)
+
+
 @pytest.fixture(params=[Path, str])
 def dicom_path(request, tmp_path):
     path = tmp_path / "test.dcm"
@@ -326,7 +348,6 @@ def test_preprocess_slices_with_z_spacing_interpolation(multiple_dicom_paths):
         crop=False,
         spacing=(1.0, 1.0, 5.0),  # Include z-spacing
         volume_handler="keep",
-        size=(32, 32),
     )
 
     results_with_z = dp.preprocess_f32_slices(multiple_dicom_paths, preprocessor_with_z, parallel=False)
@@ -335,8 +356,9 @@ def test_preprocess_slices_with_z_spacing_interpolation(multiple_dicom_paths):
     assert len(results_with_z) > 0
 
     # All outputs should have same spatial dimensions
+    spatial_shape = results_with_z[0].shape[1:3]
     for result in results_with_z:
-        assert result.shape[1:3] == (32, 32)
+        assert result.shape[1:3] == spatial_shape
 
 
 def test_preprocess_stream_slices_combined_volume(multiple_dicom_streams):


### PR DESCRIPTION
## Motivation

Invalid preprocessing configuration could reach image indexing, arithmetic, and allocation. Confirmed cases included a zero-frame `CentralSlice` panic, zero-sized padding underflow, non-finite or non-positive spacing, and a zero interpolation target silently retaining one frame.

Fixes #95

## Solution

Add one public `Preprocessor::validate()` that returns a structured, field-specific Rust error. Call it before single-object and batch preparation, use it when constructing Python preprocessors, and retain CLI-side value parsing so invalid command-line values fail before any file work. Separately reject a resolved zero-frame DICOM before selecting a volume handler.

## Changes

- validate mutually exclusive size and spacing configuration
- require nonzero dimensions and target frame counts
- require finite, strictly positive x, y, and optional z spacing
- require finite border fractions in the inclusive 0.0 to 0.5 range
- reject zero-frame DICOM metadata before `CentralSlice`, `LaplacianMip`, or another handler indexes a frame plan
- map Python constructor failures to `ValueError`
- reject the same size, spacing, frame-count, and border values in CLI parsing
- update the z-spacing integration test to follow the existing size/spacing exclusivity contract

## Test plan

- [x] Confirm the zero-frame `CentralSlice` regression panics before the change
- [x] Confirm all 12 Python invalid configurations are accepted before the change
- [x] Confirm the CLI boundary cases are accepted before the change
- [x] Run focused Rust, CLI, and Python regressions
- [x] `make quality`
- [x] `make test`

Generated with Codex.