### PR TITLE
Return Python NumPy arrays without temporary TIFFs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,10 @@ pyo3 = { version = "0.29", optional = true }
 numpy = { version = "0.29", optional = true }
 arrow = "59.0"
 parquet = "59.0"
-tempfile = { version = "3.24", optional = true }
 csv = "1.4"
 
 [features]
-python = ["pyo3", "numpy", "tempfile", "pyo3/auto-initialize"]
+python = ["pyo3", "numpy", "pyo3/auto-initialize"]
 
 [dev-dependencies]
 tempfile = "3.24"
@@ -107,4 +106,8 @@ harness = false
 
 [[bench]]
 name = "pad"
+harness = false
+
+[[bench]]
+name = "image_array"
 harness = false

--- a/README.md
+++ b/README.md
@@ -252,10 +252,9 @@ Python bindings are provided via the `pyo3` crate. The following features are su
  - Direct preprocessing of a DICOM file or buffer into a Numpy array
  - Validating whether a DICOM file is ready for preprocessing
 
-Direct preprocessing of a DICOM file or buffer into a Numpy array is achieved using a temporary TIFF file.
-This temporary file is spooled, having an in-memory capacity of 64MB with additional space allocated on disk as needed.
-This spool size was chosen to accommodate most preprocessed 2D images without being overly burdensome.
-In the future we will support a direct conversion, avoiding the need for an intermediate TIFF file.
+Python preprocessing converts the resulting image stack directly into one NHWC NumPy array without creating an intermediate TIFF file.
+The `u8`, `u16`, and `f32` entry points use the same numeric conversion semantics as the explicit TIFF-loading APIs, and DICOM pixel decoding and preprocessing release the Python GIL.
+TIFF serialization remains available through the CLI and Rust output APIs when a persistent preprocessed file is desired.
 
 The validator API returns the same report schema as `dicom-validate --format json`.
 Validation blockers are reported in the returned dictionary rather than raised as Python exceptions.

--- a/benches/image_array.rs
+++ b/benches/image_array.rs
@@ -1,0 +1,185 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
+use dicom_preprocessing::{
+    images_to_array, DicomColorType, FrameCount, LoadFromTiff, PreprocessingMetadata, TiffSaver,
+};
+use image::{DynamicImage, ImageBuffer, Luma, Rgb};
+use ndarray::Array4;
+use num::Zero;
+use std::hint::black_box;
+use std::io::{Seek, SeekFrom};
+use std::time::Duration;
+use tempfile::spooled_tempfile;
+use tiff::decoder::Decoder;
+use tiff::encoder::compression::{Compressor, Uncompressed};
+use tiff::encoder::TiffEncoder;
+
+const FRAME_COUNTS: [usize; 2] = [1, 32];
+const DEFAULT_WIDTH: u32 = 512;
+const DEFAULT_HEIGHT: u32 = 512;
+const HIGH_RES_WIDTH: u32 = 2048;
+const HIGH_RES_HEIGHT: u32 = 1536;
+const SPOOL_SIZE: usize = 64 * 1024 * 1024;
+const HIGH_RES_BENCH_ENV: &str = "DICOM_BENCH_HIGH_RES";
+const SAMPLE_SIZE: usize = 10;
+
+fn metadata(frame_count: usize) -> PreprocessingMetadata {
+    PreprocessingMetadata {
+        flip: None,
+        crop: None,
+        resize: None,
+        padding: None,
+        resolution: None,
+        num_frames: FrameCount::from(frame_count),
+    }
+}
+
+fn tiff_round_trip<T>(images: &[DynamicImage], color_type: DicomColorType) -> (Array4<T>, u64, bool)
+where
+    T: Clone + Zero,
+    Array4<T>: LoadFromTiff<T>,
+{
+    let saver = TiffSaver::new(Compressor::Uncompressed(Uncompressed), color_type);
+    let mut buffer = spooled_tempfile(SPOOL_SIZE);
+    {
+        let mut encoder = TiffEncoder::new(&mut buffer).unwrap();
+        let metadata = metadata(images.len());
+        for image in images {
+            saver.save(&mut encoder, image, &metadata).unwrap();
+        }
+    }
+    let bytes_written = buffer.stream_position().unwrap();
+    let spilled_to_disk = buffer.is_rolled();
+    buffer.seek(SeekFrom::Start(0)).unwrap();
+    let mut decoder = Decoder::new(buffer).unwrap();
+    let array = Array4::<T>::decode(&mut decoder).unwrap();
+    (array, bytes_written, spilled_to_disk)
+}
+
+fn luma8_frames(frame_count: usize, width: u32, height: u32) -> Vec<DynamicImage> {
+    (0..frame_count)
+        .map(|frame| {
+            DynamicImage::ImageLuma8(ImageBuffer::from_fn(width, height, |x, y| {
+                Luma([((x as usize + y as usize + frame) % (u8::MAX as usize + 1)) as u8])
+            }))
+        })
+        .collect()
+}
+
+fn luma16_frames(frame_count: usize, width: u32, height: u32) -> Vec<DynamicImage> {
+    (0..frame_count)
+        .map(|frame| {
+            DynamicImage::ImageLuma16(ImageBuffer::from_fn(width, height, |x, y| {
+                Luma([((x as usize * 31 + y as usize * 17 + frame) % u16::MAX as usize) as u16])
+            }))
+        })
+        .collect()
+}
+
+fn rgb8_frames(frame_count: usize, width: u32, height: u32) -> Vec<DynamicImage> {
+    (0..frame_count)
+        .map(|frame| {
+            DynamicImage::ImageRgb8(ImageBuffer::from_fn(width, height, |x, y| {
+                Rgb([
+                    ((x as usize + frame) % (u8::MAX as usize + 1)) as u8,
+                    ((y as usize + frame) % (u8::MAX as usize + 1)) as u8,
+                    ((x as usize + y as usize + frame) % (u8::MAX as usize + 1)) as u8,
+                ])
+            }))
+        })
+        .collect()
+}
+
+fn benchmark_case<T>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    name: &str,
+    images: &[DynamicImage],
+    color_type: DicomColorType,
+) where
+    T: Clone + Zero,
+    Array4<T>: LoadFromTiff<T>,
+{
+    let (_, bytes_written, spilled_to_disk) = tiff_round_trip::<T>(images, color_type.clone());
+    let elements = images
+        .iter()
+        .map(|image| {
+            u64::from(image.width())
+                * u64::from(image.height())
+                * u64::from(image.color().channel_count())
+        })
+        .sum::<u64>();
+    let raw_bytes = images
+        .iter()
+        .map(DynamicImage::as_bytes)
+        .map(<[u8]>::len)
+        .sum::<usize>();
+    eprintln!(
+        "{name}: elements={elements}, raw_bytes={raw_bytes}, tiff_bytes={bytes_written}, spilled_to_disk={spilled_to_disk}",
+    );
+    group.throughput(Throughput::Elements(elements));
+    group.bench_with_input(
+        BenchmarkId::new("tiff_round_trip", name),
+        images,
+        |b, images| {
+            b.iter(|| black_box(tiff_round_trip::<T>(black_box(images), color_type.clone()).0))
+        },
+    );
+    group.bench_with_input(
+        BenchmarkId::new("direct_array", name),
+        images,
+        |b, images| {
+            b.iter_batched(
+                || images.to_vec(),
+                |images| black_box(images_to_array::<T>(black_box(images)).unwrap()),
+                BatchSize::LargeInput,
+            )
+        },
+    );
+}
+
+fn benchmark_dimensions(c: &mut Criterion, width: u32, height: u32) {
+    let mut group = c.benchmark_group("image-array");
+    group.sample_size(SAMPLE_SIZE);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(2));
+
+    for frame_count in FRAME_COUNTS {
+        let suffix = format!("{frame_count}x{width}x{height}");
+        benchmark_case::<u8>(
+            &mut group,
+            &format!("luma8/{suffix}"),
+            &luma8_frames(frame_count, width, height),
+            DicomColorType::Gray8(tiff::encoder::colortype::Gray8),
+        );
+        benchmark_case::<u16>(
+            &mut group,
+            &format!("luma16/{suffix}"),
+            &luma16_frames(frame_count, width, height),
+            DicomColorType::Gray16(tiff::encoder::colortype::Gray16),
+        );
+        benchmark_case::<u8>(
+            &mut group,
+            &format!("rgb8/{suffix}"),
+            &rgb8_frames(frame_count, width, height),
+            DicomColorType::RGB8(tiff::encoder::colortype::RGB8),
+        );
+    }
+    group.finish();
+}
+
+fn high_res_bench_enabled() -> bool {
+    std::env::var(HIGH_RES_BENCH_ENV).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes"
+        )
+    })
+}
+
+fn main() {
+    let mut criterion = Criterion::default().configure_from_args();
+    benchmark_dimensions(&mut criterion, DEFAULT_WIDTH, DEFAULT_HEIGHT);
+    if high_res_bench_enabled() {
+        benchmark_dimensions(&mut criterion, HIGH_RES_WIDTH, HIGH_RES_HEIGHT);
+    }
+    criterion.final_summary();
+}

--- a/src/image_array.rs
+++ b/src/image_array.rs
@@ -1,0 +1,250 @@
+use crate::{Dimensions, LoadFromTiff, TiffError};
+use image::DynamicImage;
+use ndarray::Array4;
+use num::Zero;
+use tiff::decoder::DecodingResult;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ImageArrayError {
+    #[error("cannot convert an empty image stack to an array")]
+    Empty,
+
+    #[error("image frame {frame} has dimensions {actual:?}, expected {expected:?}")]
+    DimensionMismatch {
+        frame: usize,
+        expected: Dimensions,
+        actual: Dimensions,
+    },
+
+    #[error("image frame {frame} has unsupported color type {color_type:?}")]
+    UnsupportedColorType {
+        frame: usize,
+        color_type: image::ColorType,
+    },
+
+    #[error("image frame {frame} uses a different sample type from the first frame")]
+    MixedSampleTypes { frame: usize },
+
+    #[error("failed to convert image samples: {0}")]
+    SampleConversion(#[from] TiffError),
+
+    #[error("failed to construct image array: {0}")]
+    Shape(#[from] ndarray::ShapeError),
+}
+
+enum ImageSamples {
+    U8(Vec<u8>),
+    U16(Vec<u16>),
+}
+
+/// Convert a homogeneous image stack into an NHWC array without TIFF serialization.
+///
+/// Supported image variants are `Luma8`, `Luma16`, and `Rgb8`. Numeric conversion
+/// delegates to [`LoadFromTiff`] so direct arrays have the same dtype semantics as
+/// explicit TIFF loading.
+pub fn images_to_array<T>(images: Vec<DynamicImage>) -> Result<Array4<T>, ImageArrayError>
+where
+    T: Clone + Zero,
+    Array4<T>: LoadFromTiff<T>,
+{
+    let first = images.first().ok_or(ImageArrayError::Empty)?;
+    let frame_dimensions = Dimensions::from(first);
+    for (frame, image) in images.iter().enumerate().skip(1) {
+        let actual = Dimensions::from(image);
+        if actual != frame_dimensions {
+            return Err(ImageArrayError::DimensionMismatch {
+                frame,
+                expected: frame_dimensions,
+                actual,
+            });
+        }
+    }
+
+    let dimensions = frame_dimensions.with_num_frames(images.len());
+    let mut samples = match first {
+        DynamicImage::ImageLuma8(_) | DynamicImage::ImageRgb8(_) => {
+            ImageSamples::U8(Vec::with_capacity(dimensions.numel()))
+        }
+        DynamicImage::ImageLuma16(_) => ImageSamples::U16(Vec::with_capacity(dimensions.numel())),
+        _ => {
+            return Err(ImageArrayError::UnsupportedColorType {
+                frame: 0,
+                color_type: first.color(),
+            })
+        }
+    };
+
+    for (frame, image) in images.into_iter().enumerate() {
+        match (&mut samples, image) {
+            (ImageSamples::U8(samples), DynamicImage::ImageLuma8(image)) => {
+                samples.extend(image.into_raw());
+            }
+            (ImageSamples::U8(samples), DynamicImage::ImageRgb8(image)) => {
+                samples.extend(image.into_raw());
+            }
+            (ImageSamples::U16(samples), DynamicImage::ImageLuma16(image)) => {
+                samples.extend(image.into_raw());
+            }
+            (_, image @ (DynamicImage::ImageLuma8(_) | DynamicImage::ImageRgb8(_)))
+            | (_, image @ DynamicImage::ImageLuma16(_)) => {
+                let _ = image;
+                return Err(ImageArrayError::MixedSampleTypes { frame });
+            }
+            (_, image) => {
+                return Err(ImageArrayError::UnsupportedColorType {
+                    frame,
+                    color_type: image.color(),
+                })
+            }
+        }
+    }
+
+    let decoded = match samples {
+        ImageSamples::U8(samples) => DecodingResult::U8(samples),
+        ImageSamples::U16(samples) => DecodingResult::U16(samples),
+    };
+    let samples = Array4::<T>::to_vec(decoded)?;
+    Ok(Array4::from_shape_vec(dimensions.shape(), samples)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DicomColorType, FrameCount, PreprocessingMetadata, TiffSaver};
+    use image::{ImageBuffer, Luma, Rgb, Rgba};
+    use std::fmt::Debug;
+    use std::io::{Cursor, Seek, SeekFrom};
+    use tiff::decoder::Decoder;
+    use tiff::encoder::compression::{Compressor, Uncompressed};
+    use tiff::encoder::TiffEncoder;
+
+    fn metadata(frame_count: usize) -> PreprocessingMetadata {
+        PreprocessingMetadata {
+            flip: None,
+            crop: None,
+            resize: None,
+            padding: None,
+            resolution: None,
+            num_frames: FrameCount::from(frame_count),
+        }
+    }
+
+    fn tiff_round_trip<T>(images: &[DynamicImage], color_type: DicomColorType) -> Array4<T>
+    where
+        T: Clone + Zero,
+        Array4<T>: LoadFromTiff<T>,
+    {
+        let saver = TiffSaver::new(Compressor::Uncompressed(Uncompressed), color_type);
+        let mut buffer = Cursor::new(Vec::new());
+        {
+            let mut encoder = TiffEncoder::new(&mut buffer).unwrap();
+            let metadata = metadata(images.len());
+            for image in images {
+                saver.save(&mut encoder, image, &metadata).unwrap();
+            }
+        }
+        buffer.seek(SeekFrom::Start(0)).unwrap();
+        let mut decoder = Decoder::new(buffer).unwrap();
+        Array4::<T>::decode(&mut decoder).unwrap()
+    }
+
+    fn assert_tiff_parity<T>(images: &[DynamicImage], color_type: DicomColorType)
+    where
+        T: Clone + Zero + PartialEq + Debug,
+        Array4<T>: LoadFromTiff<T>,
+    {
+        let expected = tiff_round_trip::<T>(images, color_type);
+        let actual = images_to_array::<T>(images.to_vec()).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn direct_arrays_match_tiff_round_trip_for_all_supported_types() {
+        let luma8 = (0..2)
+            .map(|frame| {
+                DynamicImage::ImageLuma8(ImageBuffer::from_fn(3, 2, |x, y| {
+                    Luma([(x + y * 3 + frame * 11) as u8])
+                }))
+            })
+            .collect::<Vec<_>>();
+        let luma16 = (0..2)
+            .map(|frame| {
+                DynamicImage::ImageLuma16(ImageBuffer::from_fn(3, 2, |x, y| {
+                    Luma([((x + y * 3 + frame * 11) * 257) as u16])
+                }))
+            })
+            .collect::<Vec<_>>();
+        let rgb8 = (0..2)
+            .map(|frame| {
+                DynamicImage::ImageRgb8(ImageBuffer::from_fn(3, 2, |x, y| {
+                    let value = (x + y * 3 + frame * 11) as u8;
+                    Rgb([value, value.wrapping_add(1), value.wrapping_add(2)])
+                }))
+            })
+            .collect::<Vec<_>>();
+
+        assert_tiff_parity::<u8>(
+            &luma8,
+            DicomColorType::Gray8(tiff::encoder::colortype::Gray8),
+        );
+        assert_tiff_parity::<u16>(
+            &luma8,
+            DicomColorType::Gray8(tiff::encoder::colortype::Gray8),
+        );
+        assert_tiff_parity::<f32>(
+            &luma8,
+            DicomColorType::Gray8(tiff::encoder::colortype::Gray8),
+        );
+        assert_tiff_parity::<u8>(
+            &luma16,
+            DicomColorType::Gray16(tiff::encoder::colortype::Gray16),
+        );
+        assert_tiff_parity::<u16>(
+            &luma16,
+            DicomColorType::Gray16(tiff::encoder::colortype::Gray16),
+        );
+        assert_tiff_parity::<f32>(
+            &luma16,
+            DicomColorType::Gray16(tiff::encoder::colortype::Gray16),
+        );
+        assert_tiff_parity::<u8>(&rgb8, DicomColorType::RGB8(tiff::encoder::colortype::RGB8));
+        assert_tiff_parity::<u16>(&rgb8, DicomColorType::RGB8(tiff::encoder::colortype::RGB8));
+        assert_tiff_parity::<f32>(&rgb8, DicomColorType::RGB8(tiff::encoder::colortype::RGB8));
+    }
+
+    #[test]
+    fn direct_array_rejects_invalid_stacks() {
+        assert!(matches!(
+            images_to_array::<u8>(vec![]),
+            Err(ImageArrayError::Empty)
+        ));
+
+        let mismatched = vec![
+            DynamicImage::ImageLuma8(ImageBuffer::new(2, 2)),
+            DynamicImage::ImageLuma8(ImageBuffer::new(3, 2)),
+        ];
+        assert!(matches!(
+            images_to_array::<u8>(mismatched),
+            Err(ImageArrayError::DimensionMismatch { frame: 1, .. })
+        ));
+
+        let mixed_sample_types = vec![
+            DynamicImage::ImageLuma8(ImageBuffer::new(2, 2)),
+            DynamicImage::ImageLuma16(ImageBuffer::new(2, 2)),
+        ];
+        assert!(matches!(
+            images_to_array::<u8>(mixed_sample_types),
+            Err(ImageArrayError::MixedSampleTypes { frame: 1 })
+        ));
+
+        let unsupported = vec![DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            2,
+            2,
+            Rgba([0, 0, 0, u8::MAX]),
+        ))];
+        assert!(matches!(
+            images_to_array::<u8>(unsupported),
+            Err(ImageArrayError::UnsupportedColorType { frame: 0, .. })
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod color;
 pub mod errors;
 pub mod file;
+pub mod image_array;
 pub mod load;
 pub mod manifest;
 pub mod metadata;
@@ -13,6 +14,7 @@ pub mod viewer;
 pub use color::*;
 pub use errors::*;
 pub use file::*;
+pub use image_array::*;
 pub use load::*;
 pub use manifest::*;
 pub use metadata::*;

--- a/src/python/preprocess.rs
+++ b/src/python/preprocess.rs
@@ -1,14 +1,12 @@
-use crate::color::DicomColorType;
+use crate::image_array::images_to_array;
 use crate::load::LoadFromTiff;
 use crate::metadata::{PreprocessingMetadata, Resolution};
 use crate::preprocess::Preprocessor;
 use crate::python::path::PyPath;
-use crate::save::TiffSaver;
 use crate::transform::resize::FilterType;
 use crate::transform::volume::{CentralSlice, InterpolateVolume, KeepVolume, VolumeHandler};
 use crate::transform::{Crop, Flip, Padding, PaddingDirection, Resize};
 use crate::volume::DEFAULT_INTERPOLATE_TARGET_FRAMES;
-use ::tiff::decoder::Decoder;
 use dicom::object::{from_reader, open_file, FileDicomObject, InMemDicomObject};
 use dicom::pixeldata::{ConvertOptions, VoiLutOption, WindowLevel};
 use ndarray::Array4;
@@ -25,14 +23,7 @@ use pyo3::{
     Bound, PyAny, PyResult, Python,
 };
 use std::clone::Clone;
-use std::io::Seek;
 use std::path::Path;
-use tempfile::spooled_tempfile;
-use tiff::encoder::compression::{Compressor, Uncompressed};
-use tiff::encoder::TiffEncoder;
-
-// We guess 64MB as enough for most preprocessed images without being burdensome.
-const SPOOL_SIZE: usize = 1024 * 1024 * 64;
 
 #[pyclass(name = "Preprocessor", from_py_object)]
 #[derive(Clone)]
@@ -435,11 +426,7 @@ impl From<PreprocessingMetadata> for PyPreprocessingMetadata {
     }
 }
 
-/*
-TODO: We preprocess by saving to a temporary TIFF file in memory, then decoding it back to an array.
-It would be faster to directly preprocess the DICOM object without an intermediate TIFF file.
- */
-fn preprocess_with_temp_tiff<'py, T>(
+fn preprocess_to_array<'py, T>(
     py: Python<'py>,
     preprocessor: &Preprocessor,
     dcm: &FileDicomObject<InMemDicomObject>,
@@ -449,12 +436,11 @@ where
     T: Clone + Zero + Element,
     Array4<T>: LoadFromTiff<T>,
 {
-    let (array, _metadata) =
-        preprocess_with_temp_tiff_and_metadata(py, preprocessor, dcm, parallel)?;
+    let (array, _metadata) = preprocess_to_array_and_metadata(py, preprocessor, dcm, parallel)?;
     Ok(array)
 }
 
-fn preprocess_with_temp_tiff_and_metadata<'py, T>(
+fn preprocess_to_array_and_metadata<'py, T>(
     py: Python<'py>,
     preprocessor: &Preprocessor,
     dcm: &FileDicomObject<InMemDicomObject>,
@@ -464,32 +450,16 @@ where
     T: Clone + Zero + Element,
     Array4<T>: LoadFromTiff<T>,
 {
-    // Run preprocessing
-    let (images, metadata) = preprocessor
-        .prepare_image(dcm, parallel)
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to prepare image: {e}")))?;
-
-    // Save the images to an in-memory temporary TIFF file
-    let color_type = DicomColorType::try_from(dcm)
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to get color type: {e}")))?;
-    let compressor = Compressor::Uncompressed(Uncompressed);
-    let saver = TiffSaver::new(compressor, color_type);
-    let mut buffer = spooled_tempfile(SPOOL_SIZE);
-    let mut encoder = TiffEncoder::new(&mut buffer)
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to create TIFF encoder: {e}")))?;
-    images
-        .into_iter()
-        .try_for_each(|image| saver.save(&mut encoder, &image, &metadata))
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to save temporary TIFF: {e}")))?;
-
-    // Decode the TIFF file back to an array
-    buffer
-        .rewind()
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to rewind buffer: {e}")))?;
-    let mut decoder = Decoder::new(buffer)
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to create decoder: {e}")))?;
-    let array = Array4::<T>::decode(&mut decoder)
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to decode TIFF: {e}")))?;
+    let (array, metadata) = py
+        .detach(|| {
+            let (images, metadata) = preprocessor
+                .prepare_image(dcm, parallel)
+                .map_err(|error| format!("Failed to prepare image: {error}"))?;
+            let array = images_to_array::<T>(images)
+                .map_err(|error| format!("Failed to create image array: {error}"))?;
+            Ok::<_, String>((array, metadata))
+        })
+        .map_err(PyRuntimeError::new_err)?;
     Ok((array.into_pyarray(py), metadata.into()))
 }
 
@@ -499,7 +469,7 @@ Input order is preserved; automatic metadata-based reordering only applies to
 single multi-frame DICOM objects.
 Returns a 5D array with shape (num_slices, num_frames, height, width, channels).
  */
-fn preprocess_slices_with_temp_tiff<'py, T>(
+fn preprocess_slices_to_arrays<'py, T>(
     py: Python<'py>,
     preprocessor: &Preprocessor,
     dcms: &[FileDicomObject<InMemDicomObject>],
@@ -510,11 +480,11 @@ where
     Array4<T>: LoadFromTiff<T>,
 {
     let (arrays, _metadata) =
-        preprocess_slices_with_temp_tiff_and_metadata(py, preprocessor, dcms, parallel)?;
+        preprocess_slices_to_arrays_and_metadata(py, preprocessor, dcms, parallel)?;
     Ok(arrays)
 }
 
-fn preprocess_slices_with_temp_tiff_and_metadata<'py, T>(
+fn preprocess_slices_to_arrays_and_metadata<'py, T>(
     py: Python<'py>,
     preprocessor: &Preprocessor,
     dcms: &[FileDicomObject<InMemDicomObject>],
@@ -530,50 +500,23 @@ where
         ));
     }
 
-    // Run batch preprocessing
-    let (batch_images, metadata) = preprocessor
-        .prepare_images_batch(dcms, parallel)
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to prepare images batch: {e}")))?;
-
-    // Get color type from first DICOM (assumed same for all slices)
-    let color_type = DicomColorType::try_from(&dcms[0])
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to get color type: {e}")))?;
-    let compressor = Compressor::Uncompressed(Uncompressed);
-    let saver = TiffSaver::new(compressor, color_type);
-
-    // Process each slice's images
-    let mut result_arrays = Vec::with_capacity(batch_images.len());
-    for images in batch_images {
-        // Create metadata for this specific slice with correct frame count
-        let slice_num_frames = images.len().into();
-        let slice_metadata = PreprocessingMetadata {
-            flip: metadata.flip,
-            crop: metadata.crop,
-            resize: metadata.resize,
-            padding: metadata.padding,
-            resolution: metadata.resolution,
-            num_frames: slice_num_frames,
-        };
-
-        // Save images to temporary TIFF
-        let mut buffer = spooled_tempfile(SPOOL_SIZE);
-        let mut encoder = TiffEncoder::new(&mut buffer)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to create TIFF encoder: {e}")))?;
-        images
-            .into_iter()
-            .try_for_each(|image| saver.save(&mut encoder, &image, &slice_metadata))
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to save temporary TIFF: {e}")))?;
-
-        // Decode the TIFF file back to an array
-        buffer
-            .rewind()
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to rewind buffer: {e}")))?;
-        let mut decoder = Decoder::new(buffer)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to create decoder: {e}")))?;
-        let array = Array4::<T>::decode(&mut decoder)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to decode TIFF: {e}")))?;
-        result_arrays.push(array.into_pyarray(py));
-    }
+    let (arrays, metadata) = py
+        .detach(|| {
+            let (batch_images, metadata) = preprocessor
+                .prepare_images_batch(dcms, parallel)
+                .map_err(|error| format!("Failed to prepare images batch: {error}"))?;
+            let arrays = batch_images
+                .into_iter()
+                .map(images_to_array::<T>)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| format!("Failed to create image array: {error}"))?;
+            Ok::<_, String>((arrays, metadata))
+        })
+        .map_err(PyRuntimeError::new_err)?;
+    let result_arrays = arrays
+        .into_iter()
+        .map(|array| array.into_pyarray(py))
+        .collect();
 
     Ok((result_arrays, metadata.into()))
 }
@@ -602,7 +545,7 @@ where
     let mut dcm = from_reader(bytes)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to create DICOM object: {e}")))?;
     Preprocessor::sanitize_dicom(&mut dcm);
-    preprocess_with_temp_tiff::<T>(py, preprocessor, &dcm, parallel)
+    preprocess_to_array::<T>(py, preprocessor, &dcm, parallel)
 }
 
 #[pyfunction]
@@ -663,7 +606,7 @@ where
     let mut dcm = open_file(path)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to open DICOM file: {e}")))?;
     Preprocessor::sanitize_dicom(&mut dcm);
-    preprocess_with_temp_tiff::<T>(py, preprocessor, &dcm, parallel)
+    preprocess_to_array::<T>(py, preprocessor, &dcm, parallel)
 }
 
 #[pyfunction]
@@ -727,7 +670,7 @@ where
         Preprocessor::sanitize_dicom(&mut dcm);
         dcms.push(dcm);
     }
-    preprocess_slices_with_temp_tiff::<T>(py, preprocessor, &dcms, parallel)
+    preprocess_slices_to_arrays::<T>(py, preprocessor, &dcms, parallel)
 }
 
 #[pyfunction]
@@ -797,7 +740,7 @@ where
         Preprocessor::sanitize_dicom(&mut dcm);
         dcms.push(dcm);
     }
-    preprocess_slices_with_temp_tiff::<T>(py, preprocessor, &dcms, parallel)
+    preprocess_slices_to_arrays::<T>(py, preprocessor, &dcms, parallel)
 }
 
 #[pyfunction]
@@ -870,7 +813,7 @@ fn preprocess_u8_with_metadata<'py>(
     let mut dcm = open_file(path)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to open DICOM file: {e}")))?;
     Preprocessor::sanitize_dicom(&mut dcm);
-    preprocess_with_temp_tiff_and_metadata::<u8>(py, &preprocessor.inner, &dcm, parallel)
+    preprocess_to_array_and_metadata::<u8>(py, &preprocessor.inner, &dcm, parallel)
 }
 
 #[pyfunction]
@@ -892,7 +835,7 @@ fn preprocess_u16_with_metadata<'py>(
     let mut dcm = open_file(path)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to open DICOM file: {e}")))?;
     Preprocessor::sanitize_dicom(&mut dcm);
-    preprocess_with_temp_tiff_and_metadata::<u16>(py, &preprocessor.inner, &dcm, parallel)
+    preprocess_to_array_and_metadata::<u16>(py, &preprocessor.inner, &dcm, parallel)
 }
 
 #[pyfunction]
@@ -914,7 +857,7 @@ fn preprocess_f32_with_metadata<'py>(
     let mut dcm = open_file(path)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to open DICOM file: {e}")))?;
     Preprocessor::sanitize_dicom(&mut dcm);
-    preprocess_with_temp_tiff_and_metadata::<f32>(py, &preprocessor.inner, &dcm, parallel)
+    preprocess_to_array_and_metadata::<f32>(py, &preprocessor.inner, &dcm, parallel)
 }
 
 #[pyfunction]
@@ -937,7 +880,7 @@ fn preprocess_stream_u8_with_metadata<'py>(
     let mut dcm = from_reader(bytes)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to create DICOM object: {e}")))?;
     Preprocessor::sanitize_dicom(&mut dcm);
-    preprocess_with_temp_tiff_and_metadata::<u8>(py, &preprocessor.inner, &dcm, parallel)
+    preprocess_to_array_and_metadata::<u8>(py, &preprocessor.inner, &dcm, parallel)
 }
 
 #[pyfunction]
@@ -960,7 +903,7 @@ fn preprocess_stream_u16_with_metadata<'py>(
     let mut dcm = from_reader(bytes)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to create DICOM object: {e}")))?;
     Preprocessor::sanitize_dicom(&mut dcm);
-    preprocess_with_temp_tiff_and_metadata::<u16>(py, &preprocessor.inner, &dcm, parallel)
+    preprocess_to_array_and_metadata::<u16>(py, &preprocessor.inner, &dcm, parallel)
 }
 
 #[pyfunction]
@@ -983,7 +926,7 @@ fn preprocess_stream_f32_with_metadata<'py>(
     let mut dcm = from_reader(bytes)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to create DICOM object: {e}")))?;
     Preprocessor::sanitize_dicom(&mut dcm);
-    preprocess_with_temp_tiff_and_metadata::<f32>(py, &preprocessor.inner, &dcm, parallel)
+    preprocess_to_array_and_metadata::<f32>(py, &preprocessor.inner, &dcm, parallel)
 }
 
 #[pyfunction]
@@ -1010,7 +953,7 @@ fn preprocess_u8_slices_with_metadata<'py>(
         Preprocessor::sanitize_dicom(&mut dcm);
         dcms.push(dcm);
     }
-    preprocess_slices_with_temp_tiff_and_metadata::<u8>(py, &preprocessor.inner, &dcms, parallel)
+    preprocess_slices_to_arrays_and_metadata::<u8>(py, &preprocessor.inner, &dcms, parallel)
 }
 
 #[pyfunction]
@@ -1037,7 +980,7 @@ fn preprocess_u16_slices_with_metadata<'py>(
         Preprocessor::sanitize_dicom(&mut dcm);
         dcms.push(dcm);
     }
-    preprocess_slices_with_temp_tiff_and_metadata::<u16>(py, &preprocessor.inner, &dcms, parallel)
+    preprocess_slices_to_arrays_and_metadata::<u16>(py, &preprocessor.inner, &dcms, parallel)
 }
 
 #[pyfunction]
@@ -1064,7 +1007,7 @@ fn preprocess_f32_slices_with_metadata<'py>(
         Preprocessor::sanitize_dicom(&mut dcm);
         dcms.push(dcm);
     }
-    preprocess_slices_with_temp_tiff_and_metadata::<f32>(py, &preprocessor.inner, &dcms, parallel)
+    preprocess_slices_to_arrays_and_metadata::<f32>(py, &preprocessor.inner, &dcms, parallel)
 }
 
 #[pyfunction]
@@ -1098,7 +1041,7 @@ fn preprocess_stream_u8_slices_with_metadata<'py>(
         Preprocessor::sanitize_dicom(&mut dcm);
         dcms.push(dcm);
     }
-    preprocess_slices_with_temp_tiff_and_metadata::<u8>(py, &preprocessor.inner, &dcms, parallel)
+    preprocess_slices_to_arrays_and_metadata::<u8>(py, &preprocessor.inner, &dcms, parallel)
 }
 
 #[pyfunction]
@@ -1132,7 +1075,7 @@ fn preprocess_stream_u16_slices_with_metadata<'py>(
         Preprocessor::sanitize_dicom(&mut dcm);
         dcms.push(dcm);
     }
-    preprocess_slices_with_temp_tiff_and_metadata::<u16>(py, &preprocessor.inner, &dcms, parallel)
+    preprocess_slices_to_arrays_and_metadata::<u16>(py, &preprocessor.inner, &dcms, parallel)
 }
 
 #[pyfunction]
@@ -1166,7 +1109,7 @@ fn preprocess_stream_f32_slices_with_metadata<'py>(
         Preprocessor::sanitize_dicom(&mut dcm);
         dcms.push(dcm);
     }
-    preprocess_slices_with_temp_tiff_and_metadata::<f32>(py, &preprocessor.inner, &dcms, parallel)
+    preprocess_slices_to_arrays_and_metadata::<f32>(py, &preprocessor.inner, &dcms, parallel)
 }
 
 #[pymodule]


### PR DESCRIPTION
## Motivation

Python preprocessing currently serializes every prepared image stack to an uncompressed temporary TIFF and immediately decodes it into a NumPy array. That duplicates work and memory traffic, and stacks larger than the 64 MiB spool threshold spill to disk.

Fixes #97

## Solution

Convert homogeneous `Luma8`, `Luma16`, and `Rgb8` image stacks directly into one NHWC `ndarray::Array4`. The conversion reuses the TIFF loader's numeric conversion functions so the `u8`, `u16`, and `f32` results preserve the existing public semantics. DICOM decoding, preprocessing, and array construction now run while the Python GIL is released.

## Changes

- add a reusable typed `images_to_array` conversion with structured errors for invalid stacks
- route all Python path, stream, slice-batch, and metadata-returning preprocessing APIs through direct conversion
- remove `tempfile` from the production Python feature dependency graph
- document the direct conversion behavior
- add exact parity tests for all 9 supported source/destination dtype combinations
- add a Criterion benchmark comparing the old TIFF round trip with direct conversion

## Benchmark results

Criterion, release mode, 10 samples, 500 ms warm-up, 2 s measurement. Values below are interval midpoints for 32-frame stacks.

| Input | Size | TIFF round trip | Direct array | Speedup | Latency reduction | Spill |
|---|---:|---:|---:|---:|---:|---:|
| Luma8 | 512×512 | 2.67 ms | 0.707 ms | 3.78× | 73.6% | no |
| Luma16 | 512×512 | 8.62 ms | 3.18 ms | 2.71× | 63.2% | no |
| RGB8 | 512×512 | 12.82 ms | 4.45 ms | 2.88× | 65.3% | no |
| Luma8 | 2048×1536 | 78.25 ms | 21.02 ms | 3.72× | 73.1% | 96 MiB avoided |
| Luma16 | 2048×1536 | 141.00 ms | 35.45 ms | 3.98× | 74.9% | 192 MiB avoided |
| RGB8 | 2048×1536 | 212.26 ms | 48.76 ms | 4.35× | 77.0% | 288 MiB avoided |

The high-resolution TIFF cases all crossed the 64 MiB threshold and rolled to disk. The direct path performs no temporary serialization.

## Test plan

- `make quality`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make test` (256 Rust library tests, 158 Python tests, and 11 Node integration tests)
- `cargo bench --bench image_array`
- `DICOM_BENCH_HIGH_RES=1 cargo bench --bench image_array -- 32x2048x1536`

Generated with Codex.