### PR TITLE
Parallelize decoding across batch DICOM inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,7 @@ harness = false
 [[bench]]
 name = "pad"
 harness = false
+
+[[bench]]
+name = "batch_preprocess"
+harness = false

--- a/benches/batch_preprocess.rs
+++ b/benches/batch_preprocess.rs
@@ -1,0 +1,69 @@
+use criterion::{BenchmarkId, Criterion, Throughput};
+use dicom::object::{open_file, FileDicomObject, InMemDicomObject};
+use dicom_preprocessing::{FilterType, KeepVolume, PaddingDirection, Preprocessor, VolumeHandler};
+use std::hint::black_box;
+use std::time::Duration;
+
+const BATCH_SIZES: [usize; 4] = [1, 8, 32, 64];
+const SAMPLE_SIZE: usize = 10;
+const RESIZE_DIMENSION: u32 = 96;
+
+fn fixture_batch(batch_size: usize) -> Vec<FileDicomObject<InMemDicomObject>> {
+    let fixture = open_file(dicom_test_files::path("pydicom/CT_small.dcm").unwrap()).unwrap();
+    (0..batch_size).map(|_| fixture.clone()).collect()
+}
+
+fn preprocessor(with_transforms: bool) -> Preprocessor {
+    Preprocessor {
+        crop: with_transforms,
+        size: with_transforms.then_some((RESIZE_DIMENSION, RESIZE_DIMENSION)),
+        spacing: None,
+        filter: FilterType::Triangle,
+        padding_direction: PaddingDirection::Center,
+        crop_max: false,
+        volume_handler: VolumeHandler::Keep(KeepVolume),
+        use_components: true,
+        use_padding: with_transforms,
+        border_frac: None,
+        target_frames: 32,
+        convert_options: Default::default(),
+    }
+}
+
+fn benchmark_mode(c: &mut Criterion, with_transforms: bool) {
+    let mode = if with_transforms {
+        "crop-resize"
+    } else {
+        "decode-only"
+    };
+    let mut group = c.benchmark_group(format!("batch-preprocess/{mode}"));
+    group.sample_size(SAMPLE_SIZE);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(2));
+    let preprocessor = preprocessor(with_transforms);
+
+    for batch_size in BATCH_SIZES {
+        let files = fixture_batch(batch_size);
+        group.throughput(Throughput::Elements(batch_size as u64));
+        for (name, parallel) in [("serial", false), ("parallel", true)] {
+            group.bench_with_input(BenchmarkId::new(name, batch_size), &files, |b, files| {
+                b.iter(|| {
+                    black_box(
+                        preprocessor
+                            .prepare_images_batch(black_box(files), parallel)
+                            .unwrap(),
+                    )
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
+fn main() {
+    eprintln!("rayon_workers={}", rayon::current_num_threads());
+    let mut criterion = Criterion::default().configure_from_args();
+    benchmark_mode(&mut criterion, false);
+    benchmark_mode(&mut criterion, true);
+    criterion.final_summary();
+}

--- a/src/errors/dicom.rs
+++ b/src/errors/dicom.rs
@@ -97,6 +97,13 @@ pub enum DicomError {
     #[snafu(display("cannot project laplacian mip from empty input frames"))]
     LaplacianMipEmptyInput,
 
+    #[snafu(display("failed to decode DICOM batch input {}: {}", input_index, source))]
+    BatchDecodeError {
+        input_index: usize,
+        #[snafu(source)]
+        source: Box<DicomError>,
+    },
+
     #[snafu(display("unsupported multi-volume DICOM frame organization: {}", reason))]
     UnsupportedMultiVolume { reason: String },
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -86,6 +86,7 @@ impl Default for Preprocessor {
 
 impl Preprocessor {
     const PARALLEL_TRANSFORM_MIN_FRAMES: usize = 2;
+    const PARALLEL_BATCH_DECODE_MIN_FILES: usize = 2;
 
     fn get_crop(&self, images: &[DynamicImage]) -> Option<Crop> {
         match self.crop {
@@ -248,6 +249,45 @@ impl Preprocessor {
             .images)
     }
 
+    fn decode_batch_input(
+        &self,
+        input_index: usize,
+        file: &FileDicomObject<InMemDicomObject>,
+        parallel_frames: bool,
+    ) -> Result<Vec<DynamicImage>, DicomError> {
+        self.decode_with_single_frame_guard(file, parallel_frames)
+            .map_err(|source| DicomError::BatchDecodeError {
+                input_index,
+                source: Box::new(source),
+            })
+    }
+
+    fn decode_batch(
+        &self,
+        files: &[FileDicomObject<InMemDicomObject>],
+        parallel: bool,
+    ) -> Result<Vec<Vec<DynamicImage>>, DicomError> {
+        if parallel && files.len() >= Self::PARALLEL_BATCH_DECODE_MIN_FILES {
+            files
+                .par_iter()
+                .enumerate()
+                .map(|(input_index, file)| self.decode_batch_input(input_index, file, false))
+                .collect()
+        } else {
+            files
+                .iter()
+                .enumerate()
+                .map(|(input_index, file)| {
+                    let parallel_frames = parallel
+                        && FrameCount::try_from(file)
+                            .map(|frame_count| u32::from(frame_count) > 1)
+                            .unwrap_or(true);
+                    self.decode_batch_input(input_index, file, parallel_frames)
+                })
+                .collect()
+        }
+    }
+
     fn prepare_volume_with_single_frame_guard(
         &self,
         file: &FileDicomObject<InMemDicomObject>,
@@ -361,15 +401,14 @@ impl Preprocessor {
             });
         }
 
-        // Decode all files and collect their images into a single volume
-        // For CT scans, each file is typically a single 2D slice
-        let mut combined_volume: Vec<DynamicImage> = Vec::new();
-        for file in files {
-            let images = self.decode_with_single_frame_guard(file, parallel)?;
-
-            // Add all frames from this file to the combined volume
-            combined_volume.extend(images);
-        }
+        // Decode across files when the batch can occupy the Rayon pool. The indexed
+        // parallel iterator preserves input order, and per-file frame parallelism is
+        // disabled to avoid nested scheduling for the common single-frame series case.
+        let mut combined_volume: Vec<DynamicImage> = self
+            .decode_batch(files, parallel)?
+            .into_iter()
+            .flatten()
+            .collect();
         let flip = inverse_standard_dbt_flip(&files[0], &combined_volume);
 
         // Try to determine the resolution from the first file's pixel spacing attributes
@@ -1442,5 +1481,54 @@ mod tests {
 
         assert_eq!(serial_metadata, parallel_metadata);
         assert_images_equal(&serial_images, &parallel_images);
+    }
+
+    #[test]
+    fn test_prepare_images_batch_parallel_preserves_mixed_input_order() {
+        let ct = open_file(dicom_test_files::path("pydicom/CT_small.dcm").unwrap()).unwrap();
+        let mr = open_file(dicom_test_files::path("pydicom/MR_small.dcm").unwrap()).unwrap();
+        let files = vec![ct.clone(), mr.clone(), ct, mr];
+        let preprocessor = Preprocessor {
+            crop: false,
+            size: None,
+            spacing: None,
+            filter: resize::FilterType::Nearest,
+            padding_direction: PaddingDirection::default(),
+            crop_max: false,
+            volume_handler: VolumeHandler::Keep(KeepVolume),
+            use_components: true,
+            use_padding: false,
+            border_frac: None,
+            target_frames: 32,
+            convert_options: ConvertOptions::default(),
+        };
+
+        let (serial, serial_metadata) = preprocessor.prepare_images_batch(&files, false).unwrap();
+        let (parallel, parallel_metadata) =
+            preprocessor.prepare_images_batch(&files, true).unwrap();
+
+        assert_ne!(serial[0][0], serial[1][0]);
+        assert_eq!(parallel, serial);
+        assert_eq!(parallel_metadata, serial_metadata);
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn test_prepare_images_batch_errors_include_input_index(#[case] parallel: bool) {
+        let valid = open_file(dicom_test_files::path("pydicom/CT_small.dcm").unwrap()).unwrap();
+        let mut missing_pixels = valid.clone();
+        missing_pixels.remove_element(tags::PIXEL_DATA);
+        let files = vec![valid, missing_pixels];
+
+        let error = Preprocessor::default()
+            .prepare_images_batch(&files, parallel)
+            .unwrap_err();
+
+        assert!(matches!(
+            &error,
+            DicomError::BatchDecodeError { input_index: 1, .. }
+        ));
+        assert!(error.to_string().contains("batch input 1"));
     }
 }

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -262,6 +262,16 @@ impl Preprocessor {
             })
     }
 
+    fn should_parallelize_batch_frames(
+        file: &FileDicomObject<InMemDicomObject>,
+        parallel: bool,
+    ) -> bool {
+        parallel
+            && FrameCount::try_from(file)
+                .map(|frame_count| u32::from(frame_count) > 1)
+                .unwrap_or(true)
+    }
+
     fn decode_batch(
         &self,
         files: &[FileDicomObject<InMemDicomObject>],
@@ -271,17 +281,17 @@ impl Preprocessor {
             files
                 .par_iter()
                 .enumerate()
-                .map(|(input_index, file)| self.decode_batch_input(input_index, file, false))
+                .map(|(input_index, file)| {
+                    let parallel_frames = Self::should_parallelize_batch_frames(file, parallel);
+                    self.decode_batch_input(input_index, file, parallel_frames)
+                })
                 .collect()
         } else {
             files
                 .iter()
                 .enumerate()
                 .map(|(input_index, file)| {
-                    let parallel_frames = parallel
-                        && FrameCount::try_from(file)
-                            .map(|frame_count| u32::from(frame_count) > 1)
-                            .unwrap_or(true);
+                    let parallel_frames = Self::should_parallelize_batch_frames(file, parallel);
                     self.decode_batch_input(input_index, file, parallel_frames)
                 })
                 .collect()
@@ -1481,6 +1491,27 @@ mod tests {
 
         assert_eq!(serial_metadata, parallel_metadata);
         assert_images_equal(&serial_images, &parallel_images);
+    }
+
+    #[test]
+    fn test_batch_parallelism_keeps_multiframe_decode_parallel() {
+        let single_frame =
+            open_file(dicom_test_files::path("pydicom/CT_small.dcm").unwrap()).unwrap();
+        let multi_frame =
+            open_file(dicom_test_files::path("pydicom/emri_small.dcm").unwrap()).unwrap();
+
+        assert!(!Preprocessor::should_parallelize_batch_frames(
+            &single_frame,
+            true
+        ));
+        assert!(Preprocessor::should_parallelize_batch_frames(
+            &multi_frame,
+            true
+        ));
+        assert!(!Preprocessor::should_parallelize_batch_frames(
+            &multi_frame,
+            false
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`Preprocessor::prepare_images_batch(..., true)` decoded its input files sequentially. Each common single-frame CT object was sent to a frame-parallel decoder with only one frame, so callers paid Rayon overhead without parallelizing the batch.

Fixes #99

## Solution

Use Rayon's indexed parallel iterator across two or more batch inputs while ordered collection preserves the input sequence. Multi-frame inputs retain frame-level parallel decoding within Rayon's shared worker pool, including small batches of large volumes. Single-frame inputs avoid unnecessary frame-level fan-out.

Decode failures now carry the failing batch input index without discarding the original structured `DicomError`.

## Changes

- parallelize independent file decodes for multi-input batches
- preserve deterministic file and frame order
- retain frame-level parallel decoding for multi-frame inputs inside a parallel file batch
- keep single-frame calls on the low-overhead serial decoder
- add mixed-fixture order parity tests
- add serial and parallel indexed-error regressions
- add Criterion coverage for 1, 8, 32, and 64 files with transforms disabled and with crop/resize enabled

## Benchmark results

Criterion release build on a 48-worker Rayon pool, 10 samples, 500 ms warm-up, 2 s measurement. Fixtures were cloned before the timed region.

| Path | Files | Before parallel | After parallel | Speedup |
|---|---:|---:|---:|---:|
| Decode only | 1 | 3.578 ms | 3.038 ms | 1.18× |
| Decode only | 8 | 27.502 ms | 2.380 ms | 11.55× |
| Decode only | 32 | 114.14 ms | 5.318 ms | 21.46× |
| Decode only | 64 | 206.12 ms | 8.109 ms | 25.42× |
| Crop + resize | 1 | 4.040 ms | 3.967 ms | within noise |
| Crop + resize | 8 | 32.711 ms | 9.039 ms | 3.62× |
| Crop + resize | 32 | 109.19 ms | 19.711 ms | 5.54× |
| Crop + resize | 64 | 199.62 ms | 33.678 ms | 5.93× |

Serial measurements remained within noise, confirming the gain comes from file-level parallel decoding rather than unrelated benchmark drift.

## Test plan

- `cargo test test_prepare_images_batch --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make quality`
- `cargo test --workspace --all-features` (284 Rust library tests plus all workspace suites)
- isolated Python test environment (172 tests)
- `cargo bench --bench batch_preprocess`

Generated with Codex.