### PR TITLE
Add geometry-aware single-frame series preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Below are example images demonstrating various volume handling options. Laplacia
 
 The Laplacian MIP handler supports different projection modes for computing the central frame used in pyramid fusion. The default (`parallel-beam`) sums all slices along the z-axis, providing better depth integration. `central-slice` uses the middle slice directly, preserving single-slice sharpness.
 
-For single-file multi-frame inputs, preprocessing now resolves frame order from DICOM metadata before applying any volume handler. The precedence is dimension indices, stack ordinals, and then non-sampled patient geometry. Sampled/projection-style frames such as `TOMO_PROJ` are not slice-sorted from geometry alone, and the `*_slices` APIs still preserve caller input order.
+For single-file multi-frame inputs, preprocessing resolves frame order from DICOM metadata before applying any volume handler. The precedence is dimension indices, stack ordinals, and then non-sampled patient geometry. Sampled/projection-style frames such as `TOMO_PROJ` are not slice-sorted from geometry alone. Multi-file `prepare_images_batch` and Python `*_slices` calls preserve caller order; Rust callers can opt into `Preprocessor::prepare_series` to validate one single-frame series, order it from patient geometry, derive center-to-center z spacing, and receive source-index provenance.
 
 | Parallel Beam (default) | Central Slice |
 |-------------------------|---------------|

--- a/src/errors/dicom.rs
+++ b/src/errors/dicom.rs
@@ -97,6 +97,9 @@ pub enum DicomError {
     #[snafu(display("cannot project laplacian mip from empty input frames"))]
     LaplacianMipEmptyInput,
 
+    #[snafu(display("invalid DICOM series input {}: {}", input_index, reason))]
+    InvalidSeriesInput { input_index: usize, reason: String },
+
     #[snafu(display("unsupported multi-volume DICOM frame organization: {}", reason))]
     UnsupportedMultiVolume { reason: String },
 

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -10,6 +10,9 @@ pub use resolution::*;
 pub mod frame_order;
 pub use frame_order::*;
 
+pub mod series;
+pub use series::*;
+
 pub mod preprocessing;
 pub use preprocessing::*;
 

--- a/src/metadata/series.rs
+++ b/src/metadata/series.rs
@@ -10,6 +10,7 @@ const SPACING_ABSOLUTE_TOLERANCE_MM: f64 = 1.0e-3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SeriesOrderStrategy {
+    RawPreserved,
     Geometry,
     InstanceNumber,
 }
@@ -60,6 +61,21 @@ pub fn resolve_series_order(
         }
         let actual = compatibility(file, input_index)?;
         validate_compatibility(&reference, &actual, input_index)?;
+    }
+
+    let sampled = files.iter().map(is_sampled).collect::<Vec<_>>();
+    if sampled.iter().any(|sampled| *sampled) {
+        if let Some(input_index) = sampled.iter().position(|sampled| !sampled) {
+            return Err(invalid(
+                input_index,
+                "Volumetric Properties must consistently identify sampled projections",
+            ));
+        }
+        return Ok(SeriesOrderPlan {
+            source_indices: (0..files.len()).collect(),
+            strategy: SeriesOrderStrategy::RawPreserved,
+            z_spacing_mm: None,
+        });
     }
 
     let positions = files
@@ -356,6 +372,23 @@ fn string_value(file: &FileDicomObject<InMemDicomObject>, tag: dicom::core::Tag)
         .map(|value| value.trim().to_string())
 }
 
+fn is_sampled(file: &FileDicomObject<InMemDicomObject>) -> bool {
+    string_value(file, tags::VOLUMETRIC_PROPERTIES)
+        .or_else(|| {
+            file.iter().find_map(|element| {
+                element
+                    .items()
+                    .and_then(|items| items.first())
+                    .and_then(|item| {
+                        item.get(tags::VOLUMETRIC_PROPERTIES)
+                            .and_then(|element| element.to_str().ok())
+                            .map(|value| value.trim().to_string())
+                    })
+            })
+        })
+        .is_some_and(|value| value.eq_ignore_ascii_case("SAMPLED"))
+}
+
 fn int_value(file: &FileDicomObject<InMemDicomObject>, tag: dicom::core::Tag) -> Option<u32> {
     file.get(tag)?.to_int::<u32>().ok()
 }
@@ -482,6 +515,28 @@ mod tests {
 
         assert_eq!(plan.strategy, SeriesOrderStrategy::InstanceNumber);
         assert_eq!(plan.source_indices, vec![1, 2, 0]);
+        assert_eq!(plan.z_spacing_mm, None);
+    }
+
+    #[test]
+    fn sampled_projection_geometry_preserves_input_order() {
+        let mut files = vec![
+            series_file(Some([0.0, 0.0, 2.0]), Some(AXIAL), 3),
+            series_file(Some([0.0, 0.0, 0.0]), Some(AXIAL), 1),
+            series_file(Some([0.0, 0.0, 1.0]), Some(AXIAL), 2),
+        ];
+        for file in &mut files {
+            file.put_element(DataElement::new(
+                tags::VOLUMETRIC_PROPERTIES,
+                VR::CS,
+                "SAMPLED",
+            ));
+        }
+
+        let plan = resolve_series_order(&files).unwrap();
+
+        assert_eq!(plan.strategy, SeriesOrderStrategy::RawPreserved);
+        assert_eq!(plan.source_indices, vec![0, 1, 2]);
         assert_eq!(plan.z_spacing_mm, None);
     }
 

--- a/src/metadata/series.rs
+++ b/src/metadata/series.rs
@@ -1,0 +1,583 @@
+use crate::errors::DicomError;
+use crate::metadata::{pixel_spacing_mm, FrameCount};
+use dicom::dictionary_std::tags;
+use dicom::object::{FileDicomObject, InMemDicomObject};
+use std::cmp::Ordering;
+
+const VALUE_TOLERANCE: f64 = 1.0e-4;
+const SPACING_RELATIVE_TOLERANCE: f64 = 0.05;
+const SPACING_ABSOLUTE_TOLERANCE_MM: f64 = 1.0e-3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeriesOrderStrategy {
+    Geometry,
+    InstanceNumber,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SeriesOrderPlan {
+    /// Original input indexes in prepared slice order.
+    pub source_indices: Vec<usize>,
+    pub strategy: SeriesOrderStrategy,
+    /// Center-to-center spacing from geometry, or Spacing Between Slices when
+    /// geometry is unavailable. Slice Thickness is never used as spacing.
+    pub z_spacing_mm: Option<f32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct Compatibility {
+    series_instance_uid: String,
+    frame_of_reference_uid: String,
+    rows: u32,
+    columns: u32,
+    samples_per_pixel: u16,
+    bits_allocated: u16,
+    photometric_interpretation: String,
+    pixel_spacing_mm: [f32; 2],
+}
+
+/// Validate and order a single-frame DICOM series.
+///
+/// Complete Image Position/Orientation geometry takes precedence. Monotonic input,
+/// including descending input, retains its direction; mixed input is sorted by
+/// projected position. If geometry is absent from every input, Instance Number is
+/// used with the same monotonic-preservation rule. Partial geometry is rejected.
+pub fn resolve_series_order(
+    files: &[FileDicomObject<InMemDicomObject>],
+) -> Result<SeriesOrderPlan, DicomError> {
+    if files.is_empty() {
+        return Err(invalid(0, "series is empty"));
+    }
+
+    let reference = compatibility(&files[0], 0)?;
+    for (input_index, file) in files.iter().enumerate() {
+        let frame_count: u32 = FrameCount::try_from(file)?.into();
+        if frame_count != 1 {
+            return Err(invalid(
+                input_index,
+                format!("expected one frame, found {frame_count}"),
+            ));
+        }
+        let actual = compatibility(file, input_index)?;
+        validate_compatibility(&reference, &actual, input_index)?;
+    }
+
+    let positions = files
+        .iter()
+        .map(|file| float_values::<3>(file, tags::IMAGE_POSITION_PATIENT))
+        .collect::<Vec<_>>();
+    let orientations = files
+        .iter()
+        .map(|file| float_values::<6>(file, tags::IMAGE_ORIENTATION_PATIENT))
+        .collect::<Vec<_>>();
+    let geometry_count = positions
+        .iter()
+        .zip(&orientations)
+        .filter(|(position, orientation)| position.is_some() && orientation.is_some())
+        .count();
+
+    if geometry_count == files.len() {
+        return geometry_order(&positions, &orientations);
+    }
+    if geometry_count != 0
+        || positions.iter().any(Option::is_some)
+        || orientations.iter().any(Option::is_some)
+    {
+        let input_index = positions
+            .iter()
+            .zip(&orientations)
+            .position(|(position, orientation)| position.is_none() || orientation.is_none())
+            .unwrap_or(0);
+        return Err(invalid(
+            input_index,
+            "Image Position Patient and Image Orientation Patient must be present on every input",
+        ));
+    }
+
+    instance_number_order(files)
+}
+
+fn compatibility(
+    file: &FileDicomObject<InMemDicomObject>,
+    input_index: usize,
+) -> Result<Compatibility, DicomError> {
+    Ok(Compatibility {
+        series_instance_uid: string_value(file, tags::SERIES_INSTANCE_UID)
+            .ok_or_else(|| invalid(input_index, "missing Series Instance UID"))?,
+        frame_of_reference_uid: string_value(file, tags::FRAME_OF_REFERENCE_UID)
+            .ok_or_else(|| invalid(input_index, "missing Frame of Reference UID"))?,
+        rows: int_value(file, tags::ROWS)
+            .ok_or_else(|| invalid(input_index, "missing or invalid Rows"))?,
+        columns: int_value(file, tags::COLUMNS)
+            .ok_or_else(|| invalid(input_index, "missing or invalid Columns"))?,
+        samples_per_pixel: int_value(file, tags::SAMPLES_PER_PIXEL)
+            .and_then(|value| u16::try_from(value).ok())
+            .ok_or_else(|| invalid(input_index, "missing or invalid Samples Per Pixel"))?,
+        bits_allocated: int_value(file, tags::BITS_ALLOCATED)
+            .and_then(|value| u16::try_from(value).ok())
+            .ok_or_else(|| invalid(input_index, "missing or invalid Bits Allocated"))?,
+        photometric_interpretation: string_value(file, tags::PHOTOMETRIC_INTERPRETATION)
+            .ok_or_else(|| invalid(input_index, "missing Photometric Interpretation"))?,
+        pixel_spacing_mm: pixel_spacing_mm(file)
+            .ok_or_else(|| invalid(input_index, "missing or invalid Pixel Spacing"))?,
+    })
+}
+
+fn validate_compatibility(
+    reference: &Compatibility,
+    actual: &Compatibility,
+    input_index: usize,
+) -> Result<(), DicomError> {
+    if actual.series_instance_uid != reference.series_instance_uid {
+        return Err(invalid(
+            input_index,
+            "Series Instance UID differs from input 0",
+        ));
+    }
+    if actual.frame_of_reference_uid != reference.frame_of_reference_uid {
+        return Err(invalid(
+            input_index,
+            "Frame of Reference UID differs from input 0",
+        ));
+    }
+    if actual.rows != reference.rows || actual.columns != reference.columns {
+        return Err(invalid(input_index, "image dimensions differ from input 0"));
+    }
+    if actual.samples_per_pixel != reference.samples_per_pixel
+        || actual.bits_allocated != reference.bits_allocated
+        || actual.photometric_interpretation != reference.photometric_interpretation
+    {
+        return Err(invalid(input_index, "color type differs from input 0"));
+    }
+    if actual
+        .pixel_spacing_mm
+        .iter()
+        .zip(reference.pixel_spacing_mm)
+        .any(|(actual, expected)| (*actual - expected).abs() > VALUE_TOLERANCE as f32)
+    {
+        return Err(invalid(input_index, "Pixel Spacing differs from input 0"));
+    }
+    Ok(())
+}
+
+fn geometry_order(
+    positions: &[Option<[f64; 3]>],
+    orientations: &[Option<[f64; 6]>],
+) -> Result<SeriesOrderPlan, DicomError> {
+    let reference_orientation = orientations[0].unwrap();
+    let reference_normal = normal(reference_orientation, 0)?;
+    let mut projections = Vec::with_capacity(positions.len());
+    for input_index in 0..positions.len() {
+        let orientation = orientations[input_index].unwrap();
+        if orientation
+            .iter()
+            .zip(reference_orientation)
+            .any(|(actual, expected)| (*actual - expected).abs() > VALUE_TOLERANCE)
+        {
+            return Err(invalid(
+                input_index,
+                "Image Orientation Patient differs from input 0",
+            ));
+        }
+        let projection = dot(positions[input_index].unwrap(), reference_normal);
+        projections.push(projection);
+    }
+
+    let source_indices = order_indices(&projections, true)?;
+    let ordered_positions = source_indices
+        .iter()
+        .map(|&index| projections[index])
+        .collect::<Vec<_>>();
+    let z_spacing_mm = validate_spacing(&ordered_positions, &source_indices)?;
+    Ok(SeriesOrderPlan {
+        source_indices,
+        strategy: SeriesOrderStrategy::Geometry,
+        z_spacing_mm,
+    })
+}
+
+fn instance_number_order(
+    files: &[FileDicomObject<InMemDicomObject>],
+) -> Result<SeriesOrderPlan, DicomError> {
+    let instance_numbers = files
+        .iter()
+        .enumerate()
+        .map(|(input_index, file)| {
+            file.get(tags::INSTANCE_NUMBER)
+                .and_then(|element| element.to_int::<i32>().ok())
+                .map(f64::from)
+                .ok_or_else(|| {
+                    invalid(
+                        input_index,
+                        "geometry is unavailable and Instance Number is missing or invalid",
+                    )
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(SeriesOrderPlan {
+        source_indices: order_indices(&instance_numbers, false)?,
+        strategy: SeriesOrderStrategy::InstanceNumber,
+        z_spacing_mm: spacing_between_slices(files)?,
+    })
+}
+
+fn spacing_between_slices(
+    files: &[FileDicomObject<InMemDicomObject>],
+) -> Result<Option<f32>, DicomError> {
+    let values = files
+        .iter()
+        .map(|file| {
+            file.get(tags::SPACING_BETWEEN_SLICES)
+                .and_then(|element| element.to_float64().ok())
+        })
+        .collect::<Vec<_>>();
+    if values.iter().all(Option::is_none) {
+        return Ok(None);
+    }
+    let reference = values[0].ok_or_else(|| {
+        invalid(
+            0,
+            "Spacing Between Slices must be present on every input when geometry is unavailable",
+        )
+    })?;
+    if reference <= 0.0 {
+        return Err(invalid(0, "Spacing Between Slices must be positive"));
+    }
+    for (input_index, value) in values.iter().enumerate().skip(1) {
+        let value = value.ok_or_else(|| {
+            invalid(
+                input_index,
+                "Spacing Between Slices must be present on every input when geometry is unavailable",
+            )
+        })?;
+        if (value - reference).abs() > VALUE_TOLERANCE {
+            return Err(invalid(
+                input_index,
+                "Spacing Between Slices differs from input 0",
+            ));
+        }
+    }
+    Ok(Some(reference as f32))
+}
+
+fn order_indices(values: &[f64], geometry: bool) -> Result<Vec<usize>, DicomError> {
+    for left in 0..values.len() {
+        for right in left + 1..values.len() {
+            if (values[left] - values[right]).abs() <= VALUE_TOLERANCE {
+                let name = if geometry {
+                    "projected Image Position Patient"
+                } else {
+                    "Instance Number"
+                };
+                return Err(invalid(right, format!("duplicate {name}")));
+            }
+        }
+    }
+
+    let increasing = values.windows(2).all(|pair| pair[1] > pair[0]);
+    let decreasing = values.windows(2).all(|pair| pair[1] < pair[0]);
+    if increasing || decreasing {
+        return Ok((0..values.len()).collect());
+    }
+
+    let mut indices = (0..values.len()).collect::<Vec<_>>();
+    indices.sort_by(|&left, &right| {
+        values[left]
+            .partial_cmp(&values[right])
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| left.cmp(&right))
+    });
+    Ok(indices)
+}
+
+fn validate_spacing(
+    ordered_positions: &[f64],
+    source_indices: &[usize],
+) -> Result<Option<f32>, DicomError> {
+    if ordered_positions.len() < 2 {
+        return Ok(None);
+    }
+    let gaps = ordered_positions
+        .windows(2)
+        .map(|pair| (pair[1] - pair[0]).abs())
+        .collect::<Vec<_>>();
+    let mut sorted_gaps = gaps.clone();
+    sorted_gaps.sort_by(|left, right| left.partial_cmp(right).unwrap_or(Ordering::Equal));
+    let spacing = sorted_gaps[sorted_gaps.len() / 2];
+    let tolerance = (spacing * SPACING_RELATIVE_TOLERANCE).max(SPACING_ABSOLUTE_TOLERANCE_MM);
+    if let Some(gap_index) = gaps
+        .iter()
+        .position(|gap| (*gap - spacing).abs() > tolerance)
+    {
+        return Err(invalid(
+            source_indices[gap_index + 1],
+            format!(
+                "irregular slice spacing: gap {:.6} mm differs from median {:.6} mm",
+                gaps[gap_index], spacing
+            ),
+        ));
+    }
+    Ok(Some(spacing as f32))
+}
+
+fn normal(orientation: [f64; 6], input_index: usize) -> Result<[f64; 3], DicomError> {
+    let row = [orientation[0], orientation[1], orientation[2]];
+    let column = [orientation[3], orientation[4], orientation[5]];
+    let normal = [
+        row[1] * column[2] - row[2] * column[1],
+        row[2] * column[0] - row[0] * column[2],
+        row[0] * column[1] - row[1] * column[0],
+    ];
+    let magnitude = dot(normal, normal).sqrt();
+    if magnitude <= f64::EPSILON {
+        return Err(invalid(
+            input_index,
+            "Image Orientation Patient has no valid normal",
+        ));
+    }
+    Ok(normal.map(|value| value / magnitude))
+}
+
+fn dot(left: [f64; 3], right: [f64; 3]) -> f64 {
+    left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+}
+
+fn float_values<const N: usize>(
+    file: &FileDicomObject<InMemDicomObject>,
+    tag: dicom::core::Tag,
+) -> Option<[f64; N]> {
+    let values = file.get(tag)?.to_multi_float64().ok()?;
+    values.try_into().ok()
+}
+
+fn string_value(file: &FileDicomObject<InMemDicomObject>, tag: dicom::core::Tag) -> Option<String> {
+    file.get(tag)
+        .and_then(|element| element.to_str().ok())
+        .map(|value| value.trim().to_string())
+}
+
+fn int_value(file: &FileDicomObject<InMemDicomObject>, tag: dicom::core::Tag) -> Option<u32> {
+    file.get(tag)?.to_int::<u32>().ok()
+}
+
+fn invalid(input_index: usize, reason: impl Into<String>) -> DicomError {
+    DicomError::InvalidSeriesInput {
+        input_index,
+        reason: reason.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dicom::core::{DataElement, PrimitiveValue, VR};
+    use dicom::object::open_file;
+
+    const AXIAL: [f64; 6] = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+
+    fn series_file(
+        position: Option<[f64; 3]>,
+        orientation: Option<[f64; 6]>,
+        instance_number: i32,
+    ) -> FileDicomObject<InMemDicomObject> {
+        let mut file = open_file(dicom_test_files::path("pydicom/CT_small.dcm").unwrap()).unwrap();
+        file.put_element(DataElement::new(
+            tags::SERIES_INSTANCE_UID,
+            VR::UI,
+            "1.2.826.0.1.3680043.10.100",
+        ));
+        file.put_element(DataElement::new(
+            tags::FRAME_OF_REFERENCE_UID,
+            VR::UI,
+            "1.2.826.0.1.3680043.10.200",
+        ));
+        file.put_element(DataElement::new(
+            tags::INSTANCE_NUMBER,
+            VR::IS,
+            instance_number.to_string(),
+        ));
+        file.remove_element(tags::SPACING_BETWEEN_SLICES);
+        match position {
+            Some(position) => {
+                file.put_element(DataElement::new(
+                    tags::IMAGE_POSITION_PATIENT,
+                    VR::DS,
+                    PrimitiveValue::from(position),
+                ));
+            }
+            None => {
+                file.remove_element(tags::IMAGE_POSITION_PATIENT);
+            }
+        }
+        match orientation {
+            Some(orientation) => {
+                file.put_element(DataElement::new(
+                    tags::IMAGE_ORIENTATION_PATIENT,
+                    VR::DS,
+                    PrimitiveValue::from(orientation),
+                ));
+            }
+            None => {
+                file.remove_element(tags::IMAGE_ORIENTATION_PATIENT);
+            }
+        }
+        file
+    }
+
+    #[test]
+    fn shuffled_axial_geometry_is_sorted_and_spacing_is_derived() {
+        let files = vec![
+            series_file(Some([0.0, 0.0, 2.0]), Some(AXIAL), 3),
+            series_file(Some([0.0, 0.0, 0.0]), Some(AXIAL), 1),
+            series_file(Some([0.0, 0.0, 1.0]), Some(AXIAL), 2),
+        ];
+
+        let plan = resolve_series_order(&files).unwrap();
+
+        assert_eq!(plan.strategy, SeriesOrderStrategy::Geometry);
+        assert_eq!(plan.source_indices, vec![1, 2, 0]);
+        assert_eq!(plan.z_spacing_mm, Some(1.0));
+    }
+
+    #[test]
+    fn shuffled_oblique_geometry_uses_orientation_normal() {
+        let root_half = 0.5_f64.sqrt();
+        let orientation = [1.0, 0.0, 0.0, 0.0, root_half, root_half];
+        let position = |distance: f64| [0.0, -distance * root_half, distance * root_half];
+        let files = vec![
+            series_file(Some(position(4.0)), Some(orientation), 3),
+            series_file(Some(position(0.0)), Some(orientation), 1),
+            series_file(Some(position(2.0)), Some(orientation), 2),
+        ];
+
+        let plan = resolve_series_order(&files).unwrap();
+
+        assert_eq!(plan.source_indices, vec![1, 2, 0]);
+        assert_eq!(plan.z_spacing_mm, Some(2.0));
+    }
+
+    #[test]
+    fn monotonic_descending_geometry_preserves_input_direction() {
+        let files = vec![
+            series_file(Some([0.0, 0.0, 2.0]), Some(AXIAL), 3),
+            series_file(Some([0.0, 0.0, 1.0]), Some(AXIAL), 2),
+            series_file(Some([0.0, 0.0, 0.0]), Some(AXIAL), 1),
+        ];
+
+        let plan = resolve_series_order(&files).unwrap();
+
+        assert_eq!(plan.source_indices, vec![0, 1, 2]);
+        assert_eq!(plan.z_spacing_mm, Some(1.0));
+    }
+
+    #[test]
+    fn geometry_absence_falls_back_to_instance_number() {
+        let files = vec![
+            series_file(None, None, 3),
+            series_file(None, None, 1),
+            series_file(None, None, 2),
+        ];
+
+        let plan = resolve_series_order(&files).unwrap();
+
+        assert_eq!(plan.strategy, SeriesOrderStrategy::InstanceNumber);
+        assert_eq!(plan.source_indices, vec![1, 2, 0]);
+        assert_eq!(plan.z_spacing_mm, None);
+    }
+
+    #[test]
+    fn instance_fallback_uses_spacing_between_slices_but_not_slice_thickness() {
+        let mut files = vec![series_file(None, None, 1), series_file(None, None, 2)];
+        for file in &mut files {
+            file.put_element(DataElement::new(tags::SLICE_THICKNESS, VR::DS, "9.0"));
+        }
+        assert_eq!(resolve_series_order(&files).unwrap().z_spacing_mm, None);
+
+        for file in &mut files {
+            file.put_element(DataElement::new(
+                tags::SPACING_BETWEEN_SLICES,
+                VR::DS,
+                "2.5",
+            ));
+        }
+        assert_eq!(
+            resolve_series_order(&files).unwrap().z_spacing_mm,
+            Some(2.5)
+        );
+    }
+
+    #[test]
+    fn mixed_series_is_rejected() {
+        let mut files = vec![
+            series_file(Some([0.0, 0.0, 0.0]), Some(AXIAL), 1),
+            series_file(Some([0.0, 0.0, 1.0]), Some(AXIAL), 2),
+        ];
+        files[1].put_element(DataElement::new(
+            tags::SERIES_INSTANCE_UID,
+            VR::UI,
+            "1.2.826.0.1.3680043.10.999",
+        ));
+
+        let error = resolve_series_order(&files).unwrap_err();
+
+        assert!(matches!(
+            error,
+            DicomError::InvalidSeriesInput { input_index: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn inconsistent_orientation_is_rejected() {
+        let coronal = [1.0, 0.0, 0.0, 0.0, 0.0, 1.0];
+        let files = vec![
+            series_file(Some([0.0, 0.0, 0.0]), Some(AXIAL), 1),
+            series_file(Some([0.0, 1.0, 0.0]), Some(coronal), 2),
+        ];
+
+        let error = resolve_series_order(&files).unwrap_err();
+
+        assert!(error.to_string().contains("Orientation"));
+    }
+
+    #[test]
+    fn partial_geometry_is_rejected_instead_of_falling_back() {
+        let files = vec![
+            series_file(Some([0.0, 0.0, 0.0]), Some(AXIAL), 1),
+            series_file(None, None, 2),
+        ];
+
+        let error = resolve_series_order(&files).unwrap_err();
+
+        assert!(error.to_string().contains("must be present on every input"));
+    }
+
+    #[test]
+    fn heterogeneous_dimensions_are_rejected() {
+        let mut files = vec![
+            series_file(Some([0.0, 0.0, 0.0]), Some(AXIAL), 1),
+            series_file(Some([0.0, 0.0, 1.0]), Some(AXIAL), 2),
+        ];
+        files[1].put_element(DataElement::new(
+            tags::ROWS,
+            VR::US,
+            PrimitiveValue::from(64_u16),
+        ));
+
+        let error = resolve_series_order(&files).unwrap_err();
+
+        assert!(error.to_string().contains("dimensions differ"));
+    }
+
+    #[test]
+    fn irregular_geometry_gaps_are_rejected() {
+        let files = vec![
+            series_file(Some([0.0, 0.0, 0.0]), Some(AXIAL), 1),
+            series_file(Some([0.0, 0.0, 1.0]), Some(AXIAL), 2),
+            series_file(Some([0.0, 0.0, 4.0]), Some(AXIAL), 3),
+        ];
+
+        let error = resolve_series_order(&files).unwrap_err();
+
+        assert!(error.to_string().contains("irregular slice spacing"));
+    }
+}

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -247,17 +247,34 @@ impl Preprocessor {
                 if spacing_config.spacing_mm_z.is_some() && res.frames_per_mm.is_some() =>
             {
                 let target_spacing_mm_z = spacing_config.spacing_mm_z.unwrap();
-                let target_frames_per_mm = 1.0 / target_spacing_mm_z;
                 let current_frames_per_mm = res.frames_per_mm.unwrap();
-
-                // Scale factor for frames
-                let scale_z = target_frames_per_mm / current_frames_per_mm;
-
-                // Compute target frame count based on actual current frame count
-                Some((current_frame_count as f32 * scale_z).round() as u32)
+                let source_extent_mm =
+                    current_frame_count.saturating_sub(1) as f32 / current_frames_per_mm;
+                Some((source_extent_mm / target_spacing_mm_z).round() as u32 + 1)
             }
             _ => None,
         }
+    }
+
+    fn update_z_resolution_after_resampling(
+        resolution: &mut Option<Resolution>,
+        source_frame_count: usize,
+        output_frame_count: usize,
+    ) {
+        let Some(resolution) = resolution.as_mut() else {
+            return;
+        };
+        let Some(source_frames_per_mm) = resolution.frames_per_mm else {
+            return;
+        };
+        if source_frame_count <= 1 || output_frame_count <= 1 {
+            return;
+        }
+
+        resolution.frames_per_mm = Some(
+            source_frames_per_mm * (output_frame_count - 1) as f32
+                / (source_frame_count - 1) as f32,
+        );
     }
 
     /// Apply z-direction interpolation to resample frames based on spacing
@@ -433,17 +450,13 @@ impl Preprocessor {
         if let Some(target_frames) = target_frames {
             let original_frame_count = image_data.len();
             image_data = self.interpolate_z_spacing(image_data, target_frames)?;
+            Self::update_z_resolution_after_resampling(
+                &mut resolution,
+                original_frame_count,
+                image_data.len(),
+            );
             if image_data.len() != original_frame_count {
                 frame_plan.display_frames = vec![VolumeFrameSource::Derived; image_data.len()];
-            }
-
-            // Update the z-resolution after interpolation
-            if let Some(ref mut res) = resolution {
-                if let Some(spacing_config) = self.spacing {
-                    if let Some(target_spacing_mm_z) = spacing_config.spacing_mm_z {
-                        res.frames_per_mm = Some(1.0 / target_spacing_mm_z);
-                    }
-                }
             }
         }
 
@@ -514,6 +527,8 @@ impl Preprocessor {
         files: &[FileDicomObject<InMemDicomObject>],
         parallel: bool,
     ) -> Result<PreparedSeries, DicomError> {
+        self.validate()?;
+
         let plan = resolve_series_order(files)?;
         let ordered_files = plan
             .source_indices
@@ -565,16 +580,13 @@ impl Preprocessor {
             .or_else(|| self.volume_handler.get_target_frames());
 
         if let Some(target_frames) = target_frames {
+            let original_frame_count = combined_volume.len();
             combined_volume = self.interpolate_z_spacing(combined_volume, target_frames)?;
-
-            // Update the z-resolution after interpolation
-            if let Some(ref mut res) = resolution {
-                if let Some(spacing_config) = self.spacing {
-                    if let Some(target_spacing_mm_z) = spacing_config.spacing_mm_z {
-                        res.frames_per_mm = Some(1.0 / target_spacing_mm_z);
-                    }
-                }
-            }
+            Self::update_z_resolution_after_resampling(
+                &mut resolution,
+                original_frame_count,
+                combined_volume.len(),
+            );
         }
 
         // Use the combined volume for determining common crop bounds
@@ -1881,6 +1893,25 @@ mod tests {
     }
 
     #[test]
+    fn prepare_series_validates_configuration_before_decoding() {
+        let files = vec![geometry_series_slice(0.0, 1)];
+        let preprocessor = Preprocessor {
+            target_frames: 0,
+            ..series_preprocessor(None)
+        };
+
+        let error = preprocessor.prepare_series(&files, false).unwrap_err();
+
+        assert!(matches!(
+            error,
+            DicomError::InvalidPreprocessorConfiguration {
+                field: "target_frames",
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn prepare_series_marks_z_interpolated_slices_as_derived() {
         let files = vec![
             geometry_series_slice(0.0, 1),
@@ -1894,8 +1925,8 @@ mod tests {
             .prepare_series(&files, false)
             .unwrap();
 
-        assert_eq!(prepared.image_batches.len(), 6);
-        assert_eq!(prepared.source_indices, vec![None; 6]);
+        assert_eq!(prepared.image_batches.len(), 5);
+        assert_eq!(prepared.source_indices, vec![None; 5]);
         assert_eq!(
             prepared.metadata.resolution.unwrap().frames_per_mm,
             Some(2.0)

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -1577,9 +1577,9 @@ mod tests {
         // Process the DICOM file
         let (images, metadata) = preprocessor.prepare_image(&dicom_file, false).unwrap();
 
-        // Check that the output frame count matches expected scaling
-        let expected_frame_count =
-            (native_frame_count as f32 * (native_spacing_z / target_spacing_z)).round() as usize;
+        // Preserve the endpoint-defined physical extent while targeting z spacing.
+        let native_extent_z = (native_frame_count - 1) as f32 * native_spacing_z;
+        let expected_frame_count = (native_extent_z / target_spacing_z).round() as usize + 1;
 
         assert_eq!(
             images.len(),
@@ -1594,11 +1594,16 @@ mod tests {
             .map(|f| 1.0 / f)
             .expect("Should have output z-spacing");
 
-        // Allow small floating point error
-        let tolerance = target_spacing_z * 0.05; // 5% tolerance
+        let expected_output_spacing_z = native_extent_z / (expected_frame_count - 1) as f32;
+        let output_extent_z = (images.len() - 1) as f32 * output_spacing_z;
+        let tolerance = f32::EPSILON * native_extent_z;
         assert!(
-            (output_spacing_z - target_spacing_z).abs() < tolerance,
-            "Output spacing Z should be close to target. Got {output_spacing_z} expected {target_spacing_z}"
+            (output_spacing_z - expected_output_spacing_z).abs() < tolerance,
+            "Output spacing Z should describe the realized sampling. Got {output_spacing_z} expected {expected_output_spacing_z}"
+        );
+        assert!(
+            (output_extent_z - native_extent_z).abs() < tolerance,
+            "Output extent Z should preserve source endpoints. Got {output_extent_z} expected {native_extent_z}"
         );
     }
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -7,7 +7,9 @@ use dicom::pixeldata::ConvertOptions;
 use rayon::prelude::*;
 
 use crate::errors::DicomError;
-use crate::metadata::{FrameCount, PreprocessingMetadata, Resolution};
+use crate::metadata::{
+    resolve_series_order, FrameCount, PreprocessingMetadata, Resolution, SeriesOrderStrategy,
+};
 use crate::transform::resize;
 use crate::transform::{
     inverse_standard_dbt_flip, Crop, KeepVolume, Padding, PaddingDirection, PreparedVolume, Resize,
@@ -63,6 +65,19 @@ pub struct Preprocessor {
     pub border_frac: Option<f32>,
     pub target_frames: u32,
     pub convert_options: ConvertOptions,
+}
+
+/// Geometry-aware result for a validated single-frame DICOM series.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreparedSeries {
+    pub image_batches: Vec<Vec<DynamicImage>>,
+    pub metadata: PreprocessingMetadata,
+    /// Original caller input index for each output slice. Derived z-interpolated
+    /// slices use `None` because they do not have one exact source object.
+    pub source_indices: Vec<Option<usize>>,
+    pub order_strategy: SeriesOrderStrategy,
+    /// Resolved center-to-center spacing from geometry or Spacing Between Slices.
+    pub z_spacing_mm: Option<f32>,
 }
 
 impl Default for Preprocessor {
@@ -361,6 +376,54 @@ impl Preprocessor {
             });
         }
 
+        let files = files.iter().collect::<Vec<_>>();
+        self.prepare_images_batch_impl(&files, parallel, None)
+    }
+
+    /// Validate, geometry-order, and prepare a single-frame DICOM series.
+    ///
+    /// Unlike [`Self::prepare_images_batch`], this method validates that every input
+    /// belongs to one compatible series. Complete patient geometry is used first;
+    /// Instance Number is a fallback only when geometry is absent from every input.
+    /// Mixed input is sorted, while monotonic ascending or descending input retains
+    /// its direction. Geometry-derived center spacing overrides Slice Thickness for
+    /// z-spacing interpolation.
+    pub fn prepare_series(
+        &self,
+        files: &[FileDicomObject<InMemDicomObject>],
+        parallel: bool,
+    ) -> Result<PreparedSeries, DicomError> {
+        let plan = resolve_series_order(files)?;
+        let ordered_files = plan
+            .source_indices
+            .iter()
+            .map(|&source_index| &files[source_index])
+            .collect::<Vec<_>>();
+        let mut resolution = Resolution::try_from(ordered_files[0])?;
+        resolution.frames_per_mm = plan.z_spacing_mm.map(|z_spacing_mm| 1.0 / z_spacing_mm);
+
+        let (image_batches, metadata) =
+            self.prepare_images_batch_impl(&ordered_files, parallel, Some(resolution))?;
+        let source_indices = if image_batches.len() == plan.source_indices.len() {
+            plan.source_indices.iter().copied().map(Some).collect()
+        } else {
+            vec![None; image_batches.len()]
+        };
+        Ok(PreparedSeries {
+            image_batches,
+            metadata,
+            source_indices,
+            order_strategy: plan.strategy,
+            z_spacing_mm: plan.z_spacing_mm,
+        })
+    }
+
+    fn prepare_images_batch_impl(
+        &self,
+        files: &[&FileDicomObject<InMemDicomObject>],
+        parallel: bool,
+        resolution: Option<Resolution>,
+    ) -> Result<(Vec<Vec<DynamicImage>>, PreprocessingMetadata), DicomError> {
         // Decode all files and collect their images into a single volume
         // For CT scans, each file is typically a single 2D slice
         let mut combined_volume: Vec<DynamicImage> = Vec::new();
@@ -370,10 +433,10 @@ impl Preprocessor {
             // Add all frames from this file to the combined volume
             combined_volume.extend(images);
         }
-        let flip = inverse_standard_dbt_flip(&files[0], &combined_volume);
+        let flip = inverse_standard_dbt_flip(files[0], &combined_volume);
 
         // Try to determine the resolution from the first file's pixel spacing attributes
-        let mut resolution = Resolution::try_from(&files[0]).ok();
+        let mut resolution = resolution.or_else(|| Resolution::try_from(files[0]).ok());
 
         // Apply z-spacing interpolation to the entire combined volume
         // First check if there's a spacing-based target, otherwise use VolumeHandler target
@@ -1442,5 +1505,120 @@ mod tests {
 
         assert_eq!(serial_metadata, parallel_metadata);
         assert_images_equal(&serial_images, &parallel_images);
+    }
+
+    fn geometry_series_slice(
+        position_z: f64,
+        instance_number: i32,
+    ) -> FileDicomObject<InMemDicomObject> {
+        let mut file = open_file(dicom_test_files::path("pydicom/CT_small.dcm").unwrap()).unwrap();
+        put_str_element(
+            &mut file,
+            tags::SERIES_INSTANCE_UID,
+            VR::UI,
+            "1.2.826.0.1.3680043.10.100",
+        );
+        put_str_element(
+            &mut file,
+            tags::FRAME_OF_REFERENCE_UID,
+            VR::UI,
+            "1.2.826.0.1.3680043.10.200",
+        );
+        file.put_element(DataElement::new(
+            tags::IMAGE_POSITION_PATIENT,
+            VR::DS,
+            PrimitiveValue::from([0.0_f64, 0.0, position_z]),
+        ));
+        file.put_element(DataElement::new(
+            tags::IMAGE_ORIENTATION_PATIENT,
+            VR::DS,
+            PrimitiveValue::from([1.0_f64, 0.0, 0.0, 0.0, 1.0, 0.0]),
+        ));
+        file.put_element(DataElement::new(
+            tags::INSTANCE_NUMBER,
+            VR::IS,
+            instance_number.to_string(),
+        ));
+        file
+    }
+
+    fn series_preprocessor(spacing: Option<SpacingConfig>) -> Preprocessor {
+        Preprocessor {
+            crop: false,
+            size: None,
+            spacing,
+            filter: resize::FilterType::Nearest,
+            padding_direction: PaddingDirection::default(),
+            crop_max: false,
+            volume_handler: VolumeHandler::Keep(KeepVolume),
+            use_components: true,
+            use_padding: false,
+            border_frac: None,
+            target_frames: 32,
+            convert_options: ConvertOptions::default(),
+        }
+    }
+
+    #[test]
+    fn prepare_series_orders_geometry_and_returns_source_provenance() {
+        let files = vec![
+            geometry_series_slice(2.0, 3),
+            geometry_series_slice(0.0, 1),
+            geometry_series_slice(1.0, 2),
+        ];
+        let preprocessor = series_preprocessor(None);
+
+        let prepared = preprocessor.prepare_series(&files, true).unwrap();
+
+        assert_eq!(prepared.order_strategy, SeriesOrderStrategy::Geometry);
+        assert_eq!(prepared.source_indices, vec![Some(1), Some(2), Some(0)]);
+        assert_eq!(prepared.z_spacing_mm, Some(1.0));
+        assert_eq!(prepared.image_batches.len(), 3);
+        assert_eq!(
+            prepared.metadata.resolution.unwrap().frames_per_mm,
+            Some(1.0)
+        );
+    }
+
+    #[test]
+    fn prepare_series_instance_fallback_does_not_treat_slice_thickness_as_spacing() {
+        let mut first = geometry_series_slice(2.0, 2);
+        let mut second = geometry_series_slice(0.0, 1);
+        for file in [&mut first, &mut second] {
+            file.remove_element(tags::IMAGE_POSITION_PATIENT);
+            file.remove_element(tags::IMAGE_ORIENTATION_PATIENT);
+            file.remove_element(tags::SPACING_BETWEEN_SLICES);
+        }
+        let preprocessor = series_preprocessor(None);
+
+        let prepared = preprocessor
+            .prepare_series(&[first, second], false)
+            .unwrap();
+
+        assert_eq!(prepared.order_strategy, SeriesOrderStrategy::InstanceNumber);
+        assert_eq!(prepared.source_indices, vec![Some(0), Some(1)]);
+        assert_eq!(prepared.metadata.resolution.unwrap().frames_per_mm, None);
+    }
+
+    #[test]
+    fn prepare_series_marks_z_interpolated_slices_as_derived() {
+        let files = vec![
+            geometry_series_slice(0.0, 1),
+            geometry_series_slice(1.0, 2),
+            geometry_series_slice(2.0, 3),
+        ];
+        let [spacing_y, spacing_x] = crate::metadata::pixel_spacing_mm(&files[0]).unwrap();
+        let spacing = SpacingConfig::new_3d(spacing_x, spacing_y, 0.5);
+
+        let prepared = series_preprocessor(Some(spacing))
+            .prepare_series(&files, false)
+            .unwrap();
+
+        assert_eq!(prepared.image_batches.len(), 6);
+        assert_eq!(prepared.source_indices, vec![None; 6]);
+        assert_eq!(
+            prepared.metadata.resolution.unwrap().frames_per_mm,
+            Some(2.0)
+        );
     }
 }


### PR DESCRIPTION
## Motivation

The existing multi-file batch API intentionally preserves caller order and derives resolution from the first object. That is useful for explicit ordered inputs, but unsafe as an implicit CT-series loader: shuffled slices can be interpolated in the wrong order, incompatible objects can be combined, and Slice Thickness can be treated as center-to-center spacing.

Fixes #100

## Solution

Add an explicit Rust `Preprocessor::prepare_series` path while preserving `prepare_images_batch` behavior.

The new path validates a homogeneous single-frame series, resolves slice order from Image Position Patient projected onto the Image Orientation Patient normal, derives adjacent center spacing, and returns the original source index for every exact output slice. Monotonic ascending or descending inputs preserve their direction; mixed input is sorted by projection. If geometry is absent from every object, Instance Number is the documented fallback.

Sampled projection objects are not geometry-sorted because their position metadata describes the source plane rather than independent slice centers. A consistently sampled series preserves caller order without deriving z spacing; mixed sampled/non-sampled input is rejected.

## Validation and spacing policy

- validate preprocessor configuration before resolving or decoding inputs
- require one Series Instance UID and Frame of Reference UID
- require one frame per input
- require matching dimensions, sample count, allocated bits, photometric interpretation, and pixel spacing
- require consistent complete orientation/position geometry when any geometry is present
- reject duplicate positions and gaps differing by more than 5% (minimum 0.001 mm)
- use geometry-derived spacing first
- when geometry is unavailable, accept consistent Spacing Between Slices
- never use Slice Thickness as inter-slice spacing in this API
- preserve endpoint-defined physical extent during z resampling and report realized output spacing
- mark every z-interpolated output provenance entry as `None`

Invalid inputs report the original caller index through `DicomError::InvalidSeriesInput`.

## Changes

- add reusable `resolve_series_order`, `SeriesOrderPlan`, and `SeriesOrderStrategy`
- add `PreparedSeries` with image batches, preprocessing metadata, resolved spacing, ordering strategy, and source-index provenance
- preserve sampled projection order and reject inconsistent sampled metadata
- refactor common batch transforms so ordered series preparation does not clone DICOM objects or duplicate preprocessing logic
- preserve batch-level parallel decoding and indexed decode errors from the current target branch
- document the opt-in API without changing order-preserving Python or existing Rust batch behavior
- cover shuffled axial and oblique geometry, descending input, Instance Number fallback, sampled projections, mixed series, partial/inconsistent geometry, heterogeneous dimensions, irregular gaps, configuration validation, extent-preserving spacing, exact provenance, and derived provenance

## Test plan

- `cargo test --lib series`
- `cargo test --workspace`
- `make quality`
- isolated Python 3.14 rebuild and test run (172 passed)

Generated with Codex.