### PR TITLE
Add typed Python volume handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,21 @@ This temporary file is spooled, having an in-memory capacity of 64MB with additi
 This spool size was chosen to accommodate most preprocessed 2D images without being overly burdensome.
 In the future we will support a direct conversion, avoiding the need for an intermediate TIFF file.
 
+Python exposes typed factories for the same volume handlers as Rust and Node. String names remain available, including `central` as an alias for `central-slice`.
+
+```python
+import dicom_preprocessing as dp
+
+handler = dp.VolumeHandler.laplacian_mip(
+    skip_start=2,
+    skip_end=2,
+    mip_weight=1.5,
+    projection_mode="parallel-beam",
+)
+preprocessor = dp.Preprocessor(crop=False, volume_handler=handler)
+projection = dp.preprocess_f32("/path/to/volume.dcm", preprocessor)
+```
+
 The validator API returns the same report schema as `dicom-validate --format json`.
 Validation blockers are reported in the returned dictionary rather than raised as Python exceptions.
 Runtime errors such as a missing source path still raise exceptions.

--- a/dicom_preprocessing.pyi
+++ b/dicom_preprocessing.pyi
@@ -98,6 +98,25 @@ class PreprocessingMetadata:
     resolution: Optional[Resolution]
     num_frames: int
 
+class VolumeHandler:
+    """Typed configuration for Rust volume handlers."""
+
+    @staticmethod
+    def keep() -> VolumeHandler: ...
+    @staticmethod
+    def central_slice() -> VolumeHandler: ...
+    @staticmethod
+    def max_intensity(skip_start: int = 0, skip_end: int = 0) -> VolumeHandler: ...
+    @staticmethod
+    def interpolate(target_frames: int) -> VolumeHandler: ...
+    @staticmethod
+    def laplacian_mip(
+        skip_start: int = 0,
+        skip_end: int = 0,
+        mip_weight: float = 1.5,
+        projection_mode: Literal["central-slice", "parallel-beam"] = "parallel-beam",
+    ) -> VolumeHandler: ...
+
 class Preprocessor:
     """Configuration for DICOM preprocessing.
 
@@ -110,10 +129,13 @@ class Preprocessor:
         filter: Interpolation filter for resizing. One of: nearest, triangle, catmull, gaussian, lanczos3
         padding_direction: Direction to pad when aspect ratio doesn't match target. One of: zero, center, edge
         crop_max: Whether to crop to maximum possible size
-        volume_handler: How to handle multi-frame volumes. One of: keep, central, interpolate.
+        volume_handler: How to handle multi-frame volumes. Accepts a `VolumeHandler` configuration or
+            one of: keep, central, central-slice, max-intensity, interpolate, laplacian-mip.
             - keep: Keep all frames
-            - central: Keep the central frame
+            - central / central-slice: Keep the central frame
+            - max-intensity: Compute a maximum-intensity projection
             - interpolate: Interpolate to `target_frames` using linear interpolation along z-axis
+            - laplacian-mip: Compute the default Laplacian-pyramid MIP projection
         use_components: Whether to use color components for cropping
         use_padding: Whether to pad to target size
         border_frac: Optional fraction of border to keep when cropping
@@ -144,7 +166,10 @@ class Preprocessor:
         filter: str = "triangle",
         padding_direction: str = "zero",
         crop_max: bool = True,
-        volume_handler: str = "keep",
+        volume_handler: Union[
+            VolumeHandler,
+            Literal["keep", "central", "central-slice", "max-intensity", "interpolate", "laplacian-mip"],
+        ] = "keep",
         use_components: bool = True,
         use_padding: bool = True,
         border_frac: Optional[float] = None,

--- a/src/python/preprocess.rs
+++ b/src/python/preprocess.rs
@@ -5,7 +5,10 @@ use crate::preprocess::Preprocessor;
 use crate::python::path::PyPath;
 use crate::save::TiffSaver;
 use crate::transform::resize::FilterType;
-use crate::transform::volume::{CentralSlice, InterpolateVolume, KeepVolume, VolumeHandler};
+use crate::transform::volume::{
+    CentralSlice, InterpolateVolume, KeepVolume, LaplacianMip, MaxIntensity, ProjectionMode,
+    VolumeHandler,
+};
 use crate::transform::{Crop, Flip, Padding, PaddingDirection, Resize};
 use crate::volume::DEFAULT_INTERPOLATE_TARGET_FRAMES;
 use ::tiff::decoder::Decoder;
@@ -19,7 +22,7 @@ use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3::{
-    exceptions::{PyFileNotFoundError, PyRuntimeError},
+    exceptions::{PyFileNotFoundError, PyRuntimeError, PyValueError},
     pymodule,
     types::{PyAnyMethods, PyModule},
     Bound, PyAny, PyResult, Python,
@@ -33,6 +36,143 @@ use tiff::encoder::TiffEncoder;
 
 // We guess 64MB as enough for most preprocessed images without being burdensome.
 const SPOOL_SIZE: usize = 1024 * 1024 * 64;
+
+const DEFAULT_LAPLACIAN_SKIP_FRAMES: i64 = 0;
+const DEFAULT_LAPLACIAN_MIP_WEIGHT: f64 = 1.5;
+
+#[pyclass(name = "VolumeHandler", frozen, from_py_object)]
+#[derive(Debug, Clone)]
+pub struct PyVolumeHandler {
+    inner: VolumeHandler,
+}
+
+#[pymethods]
+impl PyVolumeHandler {
+    #[staticmethod]
+    fn keep() -> Self {
+        Self {
+            inner: VolumeHandler::Keep(KeepVolume),
+        }
+    }
+
+    #[staticmethod]
+    fn central_slice() -> Self {
+        Self {
+            inner: VolumeHandler::CentralSlice(CentralSlice),
+        }
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (skip_start=0, skip_end=0))]
+    fn max_intensity(skip_start: i64, skip_end: i64) -> PyResult<Self> {
+        Ok(Self {
+            inner: VolumeHandler::MaxIntensity(MaxIntensity::new(
+                nonnegative_u32("skip_start", skip_start)?,
+                nonnegative_u32("skip_end", skip_end)?,
+            )),
+        })
+    }
+
+    #[staticmethod]
+    fn interpolate(target_frames: i64) -> PyResult<Self> {
+        Ok(Self {
+            inner: VolumeHandler::Interpolate(InterpolateVolume::new(positive_u32(
+                "target_frames",
+                target_frames,
+            )?)),
+        })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (
+        skip_start=DEFAULT_LAPLACIAN_SKIP_FRAMES,
+        skip_end=DEFAULT_LAPLACIAN_SKIP_FRAMES,
+        mip_weight=DEFAULT_LAPLACIAN_MIP_WEIGHT,
+        projection_mode="parallel-beam",
+    ))]
+    fn laplacian_mip(
+        skip_start: i64,
+        skip_end: i64,
+        mip_weight: f64,
+        projection_mode: &str,
+    ) -> PyResult<Self> {
+        if !mip_weight.is_finite() || mip_weight < 0.0 || mip_weight > f64::from(f32::MAX) {
+            return Err(PyValueError::new_err(
+                "mip_weight must be a finite non-negative number representable as float32",
+            ));
+        }
+        let projection_mode = parse_projection_mode(projection_mode)?;
+        Ok(Self {
+            inner: VolumeHandler::LaplacianMip(
+                LaplacianMip::new(
+                    nonnegative_u32("skip_start", skip_start)?,
+                    nonnegative_u32("skip_end", skip_end)?,
+                )
+                .with_mip_weight(mip_weight as f32)
+                .with_projection_mode(projection_mode),
+            ),
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("VolumeHandler({:?})", self.inner)
+    }
+}
+
+fn nonnegative_u32(name: &str, value: i64) -> PyResult<u32> {
+    u32::try_from(value).map_err(|_| {
+        PyValueError::new_err(format!("{name} must be an integer from 0 to {}", u32::MAX))
+    })
+}
+
+fn positive_u32(name: &str, value: i64) -> PyResult<u32> {
+    let value = nonnegative_u32(name, value)?;
+    if value == 0 {
+        return Err(PyValueError::new_err(format!(
+            "{name} must be greater than zero"
+        )));
+    }
+    Ok(value)
+}
+
+fn parse_projection_mode(projection_mode: &str) -> PyResult<ProjectionMode> {
+    match projection_mode.to_ascii_lowercase().as_str() {
+        "central-slice" => Ok(ProjectionMode::CentralSlice),
+        "parallel-beam" => Ok(ProjectionMode::ParallelBeam),
+        _ => Err(PyValueError::new_err(format!(
+            "Invalid projection mode: {projection_mode}"
+        ))),
+    }
+}
+
+fn parse_volume_handler(
+    volume_handler: Option<&Bound<'_, PyAny>>,
+    target_frames: u32,
+) -> PyResult<VolumeHandler> {
+    let Some(volume_handler) = volume_handler else {
+        return Ok(VolumeHandler::Keep(KeepVolume));
+    };
+    if let Ok(name) = volume_handler.extract::<String>() {
+        return match name.to_ascii_lowercase().as_str() {
+            "keep" => Ok(VolumeHandler::Keep(KeepVolume)),
+            "central" | "central-slice" => Ok(VolumeHandler::CentralSlice(CentralSlice)),
+            "max-intensity" => Ok(VolumeHandler::MaxIntensity(MaxIntensity::default())),
+            "interpolate" => Ok(VolumeHandler::Interpolate(InterpolateVolume::new(
+                positive_u32("target_frames", i64::from(target_frames))?,
+            ))),
+            "laplacian-mip" => Ok(VolumeHandler::LaplacianMip(LaplacianMip::new(0, 0))),
+            _ => Err(PyValueError::new_err(format!(
+                "Invalid volume handler: {name}"
+            ))),
+        };
+    }
+    if let Ok(config) = volume_handler.extract::<PyRef<'_, PyVolumeHandler>>() {
+        return Ok(config.inner.clone());
+    }
+    Err(PyValueError::new_err(
+        "volume_handler must be a string or VolumeHandler",
+    ))
+}
 
 #[pyclass(name = "Preprocessor", from_py_object)]
 #[derive(Clone)]
@@ -50,7 +190,7 @@ impl PyPreprocessor {
         filter="triangle",
         padding_direction="zero",
         crop_max=true,
-        volume_handler="keep",
+        volume_handler=None,
         use_components=true,
         use_padding=true,
         border_frac=None,
@@ -65,7 +205,7 @@ impl PyPreprocessor {
         filter: &str,
         padding_direction: &str,
         crop_max: bool,
-        volume_handler: &str,
+        volume_handler: Option<&Bound<'_, PyAny>>,
         use_components: bool,
         use_padding: bool,
         border_frac: Option<f32>,
@@ -98,16 +238,7 @@ impl PyPreprocessor {
             }
         };
 
-        let volume_handler = match volume_handler.to_lowercase().as_str() {
-            "keep" => VolumeHandler::Keep(KeepVolume),
-            "central" => VolumeHandler::CentralSlice(CentralSlice),
-            "interpolate" => VolumeHandler::Interpolate(InterpolateVolume::new(target_frames)),
-            _ => {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Invalid volume handler: {volume_handler}"
-                )))
-            }
-        };
+        let volume_handler = parse_volume_handler(volume_handler, target_frames)?;
 
         let convert_options = match convert_options.to_lowercase().as_str() {
             "default" => ConvertOptions::default(),
@@ -115,14 +246,13 @@ impl PyPreprocessor {
             s if s.contains(',') => {
                 let mut parts = s.split(',');
                 let (first, second) = (parts.next().unwrap(), parts.next().unwrap());
-                let window = WindowLevel {
-                    center: first
-                        .parse()
-                        .unwrap_or_else(|_| panic!("Invalid window center: {first}")),
-                    width: second
-                        .parse()
-                        .unwrap_or_else(|_| panic!("Invalid window width: {second}")),
-                };
+                let center = first.parse().map_err(|_| {
+                    PyValueError::new_err(format!("Invalid window center: {first}"))
+                })?;
+                let width = second.parse().map_err(|_| {
+                    PyValueError::new_err(format!("Invalid window width: {second}"))
+                })?;
+                let window = WindowLevel { center, width };
                 let voi_lut = VoiLutOption::Custom(window);
                 ConvertOptions::default().with_voi_lut(voi_lut)
             }
@@ -1205,6 +1335,7 @@ pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>
         preprocess_stream_f32_slices_with_metadata,
         m
     )?)?;
+    m.add_class::<PyVolumeHandler>()?;
     m.add_class::<PyPreprocessor>()?;
     m.add_class::<PyFlip>()?;
     m.add_class::<PyCrop>()?;
@@ -1213,4 +1344,58 @@ pub(crate) fn register_submodule<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>
     m.add_class::<PyResolution>()?;
     m.add_class::<PyPreprocessingMetadata>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dicom::object::open_file;
+
+    fn assert_handler_output_parity(python: PyVolumeHandler, rust: VolumeHandler) {
+        let file = open_file(dicom_test_files::path("pydicom/emri_small.dcm").unwrap()).unwrap();
+        let options = ConvertOptions::default();
+        let actual = python
+            .inner
+            .prepare_volume_with_options(&file, &options, false)
+            .unwrap()
+            .images;
+        let expected = rust
+            .prepare_volume_with_options(&file, &options, false)
+            .unwrap()
+            .images;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn typed_volume_handlers_match_direct_rust_outputs() {
+        assert_handler_output_parity(PyVolumeHandler::keep(), VolumeHandler::Keep(KeepVolume));
+        assert_handler_output_parity(
+            PyVolumeHandler::central_slice(),
+            VolumeHandler::CentralSlice(CentralSlice),
+        );
+        assert_handler_output_parity(
+            PyVolumeHandler::max_intensity(1, 2).unwrap(),
+            VolumeHandler::MaxIntensity(MaxIntensity::new(1, 2)),
+        );
+        assert_handler_output_parity(
+            PyVolumeHandler::interpolate(6).unwrap(),
+            VolumeHandler::Interpolate(InterpolateVolume::new(6)),
+        );
+        assert_handler_output_parity(
+            PyVolumeHandler::laplacian_mip(0, 0, 0.75, "central-slice").unwrap(),
+            VolumeHandler::LaplacianMip(
+                LaplacianMip::new(0, 0)
+                    .with_mip_weight(0.75)
+                    .with_projection_mode(ProjectionMode::CentralSlice),
+            ),
+        );
+    }
+
+    #[test]
+    fn typed_volume_handler_validation_returns_python_errors() {
+        assert!(PyVolumeHandler::max_intensity(-1, 0).is_err());
+        assert!(PyVolumeHandler::interpolate(0).is_err());
+        assert!(PyVolumeHandler::laplacian_mip(0, 0, f64::NAN, "parallel-beam").is_err());
+        assert!(PyVolumeHandler::laplacian_mip(0, 0, 1.5, "invalid").is_err());
+    }
 }

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -371,6 +372,127 @@ def multiframe_dicom_stream(multiframe_dicom_path):
     """Load multi-frame DICOM file as byte stream."""
     with open(multiframe_dicom_path, "rb") as f:
         return f.read()
+
+
+def volume_preprocessor(volume_handler):
+    return dp.Preprocessor(
+        crop=False,
+        size=None,
+        volume_handler=volume_handler,
+        use_padding=False,
+    )
+
+
+def test_central_slice_name_and_legacy_alias_match(multiframe_dicom_path):
+    legacy = dp.preprocess_u16(
+        multiframe_dicom_path,
+        volume_preprocessor("central"),
+        parallel=False,
+    )
+    named = dp.preprocess_u16(
+        multiframe_dicom_path,
+        volume_preprocessor("central-slice"),
+        parallel=False,
+    )
+    typed = dp.preprocess_u16(
+        multiframe_dicom_path,
+        volume_preprocessor(dp.VolumeHandler.central_slice()),
+        parallel=False,
+    )
+
+    assert np.array_equal(named, legacy)
+    assert np.array_equal(typed, legacy)
+
+
+def test_max_intensity_typed_and_named_defaults_match(multiframe_dicom_path):
+    named = dp.preprocess_u16(
+        multiframe_dicom_path,
+        volume_preprocessor("max-intensity"),
+        parallel=False,
+    )
+    typed = dp.preprocess_u16(
+        multiframe_dicom_path,
+        volume_preprocessor(dp.VolumeHandler.max_intensity()),
+        parallel=False,
+    )
+
+    assert named.shape[0] == 1
+    assert np.array_equal(typed, named)
+
+
+def test_laplacian_mip_typed_and_named_defaults_match(multiframe_dicom_path):
+    named = dp.preprocess_u16(
+        multiframe_dicom_path,
+        volume_preprocessor("laplacian-mip"),
+        parallel=False,
+    )
+    typed = dp.preprocess_u16(
+        multiframe_dicom_path,
+        volume_preprocessor(dp.VolumeHandler.laplacian_mip()),
+        parallel=False,
+    )
+
+    assert named.shape[0] == 1
+    assert np.array_equal(typed, named)
+
+
+def test_configured_projection_handlers_execute(multiframe_dicom_path):
+    handlers = [
+        dp.VolumeHandler.max_intensity(skip_start=1, skip_end=2),
+        dp.VolumeHandler.laplacian_mip(
+            skip_start=1,
+            skip_end=1,
+            mip_weight=0.75,
+            projection_mode="central-slice",
+        ),
+    ]
+
+    for handler in handlers:
+        result = dp.preprocess_u16(
+            multiframe_dicom_path,
+            volume_preprocessor(handler),
+            parallel=False,
+        )
+        assert result.shape[0] == 1
+
+
+def test_typed_interpolate_matches_legacy_configuration(multiframe_dicom_path):
+    legacy = dp.preprocess_u16(
+        multiframe_dicom_path,
+        dp.Preprocessor(crop=False, volume_handler="interpolate", target_frames=8),
+        parallel=False,
+    )
+    typed = dp.preprocess_u16(
+        multiframe_dicom_path,
+        volume_preprocessor(dp.VolumeHandler.interpolate(8)),
+        parallel=False,
+    )
+
+    assert np.array_equal(typed, legacy)
+
+
+@pytest.mark.parametrize(
+    "factory, message",
+    [
+        (lambda: dp.VolumeHandler.max_intensity(skip_start=-1), "skip_start"),
+        (lambda: dp.VolumeHandler.interpolate(0), "target_frames"),
+        (lambda: dp.VolumeHandler.laplacian_mip(mip_weight=float("nan")), "mip_weight"),
+        (
+            lambda: dp.VolumeHandler.laplacian_mip(projection_mode=cast(Any, "invalid")),
+            "projection mode",
+        ),
+    ],
+)
+def test_volume_handler_factories_reject_invalid_parameters(factory, message):
+    with pytest.raises(ValueError, match=message):
+        factory()
+
+
+def test_preprocessor_rejects_invalid_volume_handler_and_window():
+    with pytest.raises(ValueError, match="volume_handler"):
+        dp.Preprocessor(volume_handler=cast(Any, object()))
+    with pytest.raises(ValueError, match="window center"):
+        dp.Preprocessor(convert_options="invalid,1")
 
 
 @pytest.mark.parametrize("target_frames", [8, 16, 32])


### PR DESCRIPTION
## Motivation

Rust, the CLI, and Node expose keep, central slice, maximum intensity, interpolation, and Laplacian MIP. Python accepted only `keep`, `central`, and string-configured `interpolate`, forcing Python callers to bypass supported Rust behavior.

Fixes #101

## Solution

Add a frozen Python `VolumeHandler` configuration class with static factories that construct the existing Rust handler types. `Preprocessor.volume_handler` accepts either this typed object or a backward-compatible string.

Typed factories keep related options together:

```python
dp.VolumeHandler.keep()
dp.VolumeHandler.central_slice()
dp.VolumeHandler.max_intensity(skip_start=0, skip_end=0)
dp.VolumeHandler.interpolate(target_frames=32)
dp.VolumeHandler.laplacian_mip(
    skip_start=0,
    skip_end=0,
    mip_weight=1.5,
    projection_mode="parallel-beam",
)
```

## Compatibility and validation

- preserve omitted/`keep`, `central`, and string `interpolate` behavior
- accept `central-slice` as the canonical alias
- accept `max-intensity` and `laplacian-mip` string defaults
- reject negative or out-of-range skip counts with `ValueError`
- require positive interpolation frame counts
- require finite, non-negative float32-representable MIP weights
- accept only `central-slice` and `parallel-beam` projection modes
- convert malformed custom window strings to `ValueError` instead of a Rust panic

The projection string defaults use zero skipped frames, matching Node's optional-field behavior and allowing the bundled 10-frame fixture to run without extra configuration.

## Changes

- add and register typed Python volume-handler factories
- route Python configuration through Rust `MaxIntensity`, `InterpolateVolume`, and `LaplacianMip` constructors
- update the Python type stub with literal names and typed options
- add a README example
- add Rust tests comparing every Python factory's decoded images with the corresponding direct Rust handler
- add public Python tests for legacy aliases, named/typed parity, custom options, interpolation compatibility, and invalid inputs

## Test plan

- `cargo test typed_volume_handler --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make quality`
- `make test` (254 default-feature Rust library tests, 168 Python tests, and 11 Node integration tests)

Generated with Codex.