### PR TITLE
Support Windows file identifiers in native bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+    win: circleci/windows@5.0
+
 jobs:
     rust_quality:
         docker:
@@ -174,6 +177,43 @@ jobs:
                 name: Run Node tests
                 command: make test-node
 
+    windows_node_tests:
+        executor: win/server-2022
+        steps:
+            - checkout
+            - run:
+                  name: Keep public GitHub dependencies on HTTPS
+                  command: |
+                      $rewriteRules = @(git config --global --get-regexp '^url\..*\.insteadof$' 2>$null)
+                      if (($LASTEXITCODE -ne 0) -and ($LASTEXITCODE -ne 1)) {
+                          throw "Unable to inspect global Git URL rewrites"
+                      }
+                      foreach ($rule in $rewriteRules) {
+                          $name, $value = $rule -split '\s+', 2
+                          if ($value -match '^https://github\.com/?$') {
+                              git config --global --unset-all $name
+                              if ($LASTEXITCODE -ne 0) {
+                                  throw "Unable to remove Git URL rewrite '$name'"
+                              }
+                          }
+                      }
+                      exit 0
+            - run:
+                  name: Install Rust
+                  command: |
+                      Invoke-WebRequest https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+                      .\rustup-init.exe -y --default-toolchain stable
+                      $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
+                      rustc --version
+                      cargo --version
+            - run:
+                  name: Build and test Node bindings
+                  command: |
+                      $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
+                      npm --prefix bindings/node ci
+                      cargo test -p dicom-preprocessing test_inode_sort
+                      npm --prefix bindings/node run build
+
 workflows:
     build_and_test:
         jobs:
@@ -195,3 +235,4 @@ workflows:
                     - rust_quality
                     - python_quality
                     - node_quality
+            - windows_node_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,4 +235,8 @@ workflows:
                     - rust_quality
                     - python_quality
                     - node_quality
-            - windows_node_tests
+            - windows_node_tests:
+                requires:
+                    - rust_quality
+                    - python_quality
+                    - node_quality

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Python style is formatter-driven:
 - Python quality gate: `python_quality` job (Python 3.13; runs `make init-no-project` then `make quality-python`).
 - Rust runtime tests: `rust_tests` job (`cargo test --all-features`).
 - Python runtime tests: `python_tests` job (`make test-python-ci`, which uses a debug extension build).
+- Windows native-binding gate: `windows_node_tests` verifies platform file identifiers and builds the N-API module on Windows Server.
 - Test jobs are gated on both quality jobs passing.
 
 ## Testing Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Python style is formatter-driven:
 - Rust runtime tests: `rust_tests` job (`cargo test --all-features`).
 - Python runtime tests: `python_tests` job (`make test-python-ci`, which uses a debug extension build).
 - Windows native-binding gate: `windows_node_tests` verifies platform file identifiers and builds the N-API module on Windows Server.
-- Test jobs are gated on both quality jobs passing.
+- Test jobs are gated on all three quality jobs passing.
 
 ## Testing Guidelines
 Add or update tests when behavior changes in preprocessing, manifest generation, TIFF I/O, or Python bindings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "dicom-pixeldata",
  "dicom-test-files",
  "env_logger",
+ "file-id",
  "half",
  "image",
  "imageproc",
@@ -1325,6 +1326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4016,7 +4026,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4034,14 +4053,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4051,10 +4087,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4063,10 +4111,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4075,10 +4135,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4087,10 +4159,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ arrow = "59.0"
 parquet = "59.0"
 csv = "1.4"
 
+[target.'cfg(windows)'.dependencies]
+file-id = "=0.2.3"
+
 [features]
 python = ["pyo3", "numpy", "pyo3/auto-initialize"]
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -14,6 +14,7 @@ use tiff::TiffError;
 
 use indicatif::{ProgressBar, ProgressStyle};
 use rust_search::SearchBuilder;
+#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
@@ -21,6 +22,29 @@ pub const DICM_PREFIX: &[u8; 4] = b"DICM";
 pub const DICM_PREFIX_LOCATION: u64 = 128;
 
 type IOResult<T> = Result<T, std::io::Error>;
+
+#[cfg(unix)]
+fn path_file_index(path: &Path) -> IOResult<u64> {
+    Ok(std::fs::metadata(path)?.ino())
+}
+
+#[cfg(windows)]
+fn path_file_index(path: &Path) -> IOResult<u64> {
+    match file_id::get_low_res_file_id(path)? {
+        file_id::FileId::LowRes { file_index, .. } => Ok(file_index),
+        _ => Err(std::io::Error::other(
+            "Windows low-resolution file ID is unavailable",
+        )),
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn path_file_index(_path: &Path) -> IOResult<u64> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "file identifiers are unsupported on this platform",
+    ))
+}
 
 pub fn default_bar(len: u64) -> ProgressBar {
     let pb = ProgressBar::new(len);
@@ -60,19 +84,14 @@ pub trait Inode
 where
     Self: AsRef<Path>,
 {
-    /// Get the inode of a path.
+    /// Get the inode or Windows file index of a path.
     fn inode(&self) -> IOResult<u64> {
-        let metadata = std::fs::metadata(self.as_ref())?;
-        Ok(metadata.ino())
+        path_file_index(self.as_ref())
     }
 
-    /// Get the inode of a path, or a default value if an error occurs.
+    /// Get the inode or Windows file index of a path, or a default value on error.
     fn inode_or(&self, value: u64) -> u64 {
-        let metadata = std::fs::metadata(self.as_ref());
-        match metadata {
-            Ok(metadata) => metadata.ino(),
-            Err(_) => value,
-        }
+        self.inode().unwrap_or(value)
     }
 }
 
@@ -471,11 +490,8 @@ mod tests {
         // Verify we got back all files
         assert_eq!(sorted.len(), 3);
 
-        // Verify inode ordering by checking each pair is ordered
-        let inodes: Vec<u64> = sorted
-            .iter()
-            .map(|p| std::fs::metadata(p).unwrap().ino())
-            .collect();
+        // Verify file identifier ordering by checking each pair is ordered
+        let inodes: Vec<u64> = sorted.iter().map(|p| p.inode().unwrap()).collect();
 
         for i in 1..inodes.len() {
             assert!(inodes[i - 1] <= inodes[i]);

--- a/tests/test_circleci.py
+++ b/tests/test_circleci.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+QUALITY_JOBS = {"rust_quality", "python_quality", "node_quality"}
+
+
+def workflow_job_requirements(config: str, job_name: str) -> set[str]:
+    lines = config.splitlines()
+    job_markers = {f"- {job_name}", f"- {job_name}:"}
+
+    for job_index, line in enumerate(lines):
+        if line.strip() not in job_markers:
+            continue
+
+        job_indent = len(line) - len(line.lstrip())
+        for requires_index in range(job_index + 1, len(lines)):
+            requires_line = lines[requires_index]
+            requires_indent = len(requires_line) - len(requires_line.lstrip())
+            if requires_line.strip() and requires_indent <= job_indent:
+                return set()
+            if requires_line.strip() != "requires:":
+                continue
+
+            requirements = set()
+            for dependency_line in lines[requires_index + 1 :]:
+                dependency_indent = len(dependency_line) - len(dependency_line.lstrip())
+                if dependency_line.strip() and dependency_indent <= requires_indent:
+                    break
+                if dependency_line.strip().startswith("- "):
+                    requirements.add(dependency_line.strip().removeprefix("- "))
+            return requirements
+        return set()
+
+    raise AssertionError(f"Workflow job not found: {job_name}")
+
+
+def test_windows_node_tests_require_quality_jobs() -> None:
+    config = (REPOSITORY_ROOT / ".circleci" / "config.yml").read_text()
+
+    assert workflow_job_requirements(config, "windows_node_tests") == QUALITY_JOBS


### PR DESCRIPTION
## Motivation

The Node binding advertises an x86_64 Windows target, but the core library imports Unix `MetadataExt` and calls `Metadata::ino()` unconditionally. Windows native builds therefore fail before the N-API module can compile.

## Solution

Preserve native inode behavior on Unix and use Windows' low-resolution file index through the safe `file-id` crate. Keep the existing `Inode` API for compatibility while making its implementation platform-aware.

## Changes

- Gate Unix metadata extensions behind `cfg(unix)`.
- Return a Windows file index from `Inode::inode` on Windows.
- Make the inode-sort test platform-neutral.
- Add a Windows CircleCI job that tests file-identifier sorting and builds the Node binding.
- Keep public GitHub Cargo dependencies on HTTPS in the Windows job.
- Gate the paid Windows job on the Rust, Python, and Node quality jobs.
- Add a regression test for the CircleCI workflow dependency contract.

## Test plan

- [x] `make quality`
- [x] `make test`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] `npm --prefix bindings/node run build`
- [x] Isolated `x86_64-pc-windows-msvc` type-check for the `file-id` implementation
- [x] Windows CircleCI native build for the platform fix
- [x] CircleCI workflow after quality-gate review fix

## Test suite changes

- Added `test_windows_node_tests_require_quality_jobs` to enforce the Windows job's Rust, Python, and Node quality dependencies.
- No tests were removed or materially altered.

Generated with Codex