### PR TITLE
Reduce normal CircleCI runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,11 @@ jobs:
             - checkout
             - restore_cache:
                 keys:
-                  - v3-rust-quality-{{ arch }}-{{ checksum "Cargo.lock" }}
-                  - v3-rust-quality-{{ arch }}-
+                  - v4-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
+                  - v4-rust-deps-{{ arch }}-
+            - restore_cache:
+                keys:
+                  - v4-rust-quality-target-{{ arch }}-{{ checksum "Cargo.lock" }}
             - run:
                 name: Install dependencies
                 command: rustup component add rustfmt clippy
@@ -23,15 +26,14 @@ jobs:
                 name: Clippy check
                 command: cargo clippy --workspace --all-features -- -D warnings
             - save_cache:
-                key: v3-rust-quality-{{ arch }}-{{ checksum "Cargo.lock" }}
+                key: v4-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
                 paths:
-                  - ~/.cargo
-                  - ~/.rustup
+                  - ~/.cargo/registry
+                  - ~/.cargo/git
+            - save_cache:
+                key: v4-rust-quality-target-{{ arch }}-{{ checksum "Cargo.lock" }}
+                paths:
                   - ./target
-            - persist_to_workspace:
-                root: .
-                paths:
-                  - target/
 
     python_quality:
         docker:
@@ -61,23 +63,15 @@ jobs:
             - checkout
             - restore_cache:
                 keys:
-                  - v1-node-{{ checksum "bindings/node/package-lock.json" }}
-                  - v1-node-
-            - run:
-                name: Install Rust
-                command: |
-                    if [ ! -f "$HOME/.cargo/env" ]; then
-                        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-                    fi
-                    echo 'source "$HOME/.cargo/env"' >> $BASH_ENV
+                  - v2-node-{{ checksum "bindings/node/package-lock.json" }}
+                  - v2-node-
             - run:
                 name: Install Node dependencies
                 command: make init-node
             - save_cache:
-                key: v1-node-{{ checksum "bindings/node/package-lock.json" }}
+                key: v2-node-{{ checksum "bindings/node/package-lock.json" }}
                 paths:
                   - ~/.npm
-                  - bindings/node/node_modules
             - run:
                 name: Run Node quality checks
                 command: make quality-node
@@ -87,36 +81,26 @@ jobs:
             - image: rust:latest
         steps:
             - checkout
-            - attach_workspace:
-                at: .
             - restore_cache:
                 keys:
-                  - v3-rust-tests-{{ arch }}-{{ checksum "Cargo.lock" }}
-                  - v3-rust-tests-{{ arch }}-
+                  - v4-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
+                  - v4-rust-deps-{{ arch }}-
             - run:
                 name: Install Python runtime for pyo3 tests
                 command: apt-get update && apt-get install -y python3-dev
             - run:
                 name: Run Rust tests
                 command: cargo test --workspace --all-features
-            - save_cache:
-                key: v3-rust-tests-{{ arch }}-{{ checksum "Cargo.lock" }}
-                paths:
-                  - ~/.cargo
-                  - ~/.rustup
-                  - ./target
 
     python_tests:
         docker:
             - image: cimg/python:3.13
         steps:
             - checkout
-            - attach_workspace:
-                at: .
             - restore_cache:
                 keys:
-                  - v3-rust-tests-{{ arch }}-{{ checksum "Cargo.lock" }}
-                  - v3-rust-tests-{{ arch }}-
+                  - v4-python-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
+                  - v4-python-rust-deps-{{ arch }}-
             - restore_cache:
                 keys:
                   - v3-py-{{ checksum "uv.lock" }}
@@ -134,20 +118,14 @@ jobs:
             - run:
                 name: Install dependencies
                 command: make init-no-project
-            - save_cache:
-                key: v3-py-{{ checksum "uv.lock" }}
-                paths:
-                  - ~/.cache/pip
-                  - ~/.cache/uv
             - run:
                 name: Run Python tests
                 command: make test-python-ci
             - save_cache:
-                key: v3-rust-tests-{{ arch }}-{{ checksum "Cargo.lock" }}
+                key: v4-python-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
                 paths:
-                  - ~/.cargo
-                  - ~/.rustup
-                  - ./target
+                  - ~/.cargo/registry
+                  - ~/.cargo/git
 
     node_tests:
         docker:
@@ -156,8 +134,12 @@ jobs:
             - checkout
             - restore_cache:
                 keys:
-                  - v1-node-{{ checksum "bindings/node/package-lock.json" }}
-                  - v1-node-
+                  - v2-node-{{ checksum "bindings/node/package-lock.json" }}
+                  - v2-node-
+            - restore_cache:
+                keys:
+                  - v4-node-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
+                  - v4-node-rust-deps-{{ arch }}-
             - run:
                 name: Install Rust
                 command: |
@@ -168,14 +150,14 @@ jobs:
             - run:
                 name: Install Node dependencies
                 command: make init-node
-            - save_cache:
-                key: v1-node-{{ checksum "bindings/node/package-lock.json" }}
-                paths:
-                  - ~/.npm
-                  - bindings/node/node_modules
             - run:
                 name: Run Node tests
                 command: make test-node
+            - save_cache:
+                key: v4-node-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
+                paths:
+                  - ~/.cargo/registry
+                  - ~/.cargo/git
 
     windows_node_tests:
         executor: win/server-2022
@@ -198,6 +180,10 @@ jobs:
                           }
                       }
                       exit 0
+            - restore_cache:
+                  keys:
+                    - v4-windows-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
+                    - v4-windows-rust-deps-{{ arch }}-
             - run:
                   name: Install Rust
                   command: |
@@ -207,36 +193,62 @@ jobs:
                       rustc --version
                       cargo --version
             - run:
-                  name: Build and test Node bindings
+                  name: Install Node dependencies
+                  command: |
+                      npm --prefix bindings/node ci
+            - run:
+                  name: Test Windows file identifiers
                   command: |
                       $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
-                      npm --prefix bindings/node ci
-                      cargo test -p dicom-preprocessing test_inode_sort
-                      npm --prefix bindings/node run build
+                      cargo test -p dicom-preprocessing --lib file::tests::test_inode_sort
+            - run:
+                  name: Build Node bindings
+                  command: |
+                      $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
+                      $nodeBuild = if ($env:CIRCLE_TAG -match '^v[0-9]+\.[0-9]+\.[0-9]+$') {
+                          "build"
+                      } else {
+                          "build:debug"
+                      }
+                      npm --prefix bindings/node run $nodeBuild
+            - save_cache:
+                  key: v4-windows-rust-deps-{{ arch }}-{{ checksum "Cargo.lock" }}
+                  paths:
+                    - 'C:\Users\circleci\.cargo\registry'
+                    - 'C:\Users\circleci\.cargo\git'
 
 workflows:
     build_and_test:
         jobs:
-            - rust_quality
-            - python_quality
+            - rust_quality:
+                filters: &version_tags
+                    tags:
+                        only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+            - python_quality:
+                filters: *version_tags
             - rust_tests:
                 requires:
                     - rust_quality
                     - python_quality
                     - node_quality
+                filters: *version_tags
             - python_tests:
                 requires:
                     - rust_quality
                     - python_quality
                     - node_quality
-            - node_quality
+                filters: *version_tags
+            - node_quality:
+                filters: *version_tags
             - node_tests:
                 requires:
                     - rust_quality
                     - python_quality
                     - node_quality
+                filters: *version_tags
             - windows_node_tests:
                 requires:
                     - rust_quality
                     - python_quality
                     - node_quality
+                filters: *version_tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,12 @@ jobs:
                   name: Test Windows file identifiers
                   command: |
                       $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
-                      cargo test -p dicom-preprocessing --lib file::tests::test_inode_sort
+                      $rustTargetLine = rustc -vV | Select-String '^host: '
+                      if ($null -eq $rustTargetLine) {
+                          throw "Unable to detect the Rust host target"
+                      }
+                      $rustTarget = $rustTargetLine.Line.Substring(6)
+                      cargo test -p dicom-preprocessing --lib file::tests::test_inode_sort --target $rustTarget
             - run:
                   name: Build Node bindings
                   command: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Python style is formatter-driven:
 - Rust runtime tests: `rust_tests` job (`cargo test --workspace --all-features`).
 - Python runtime tests: `python_tests` job (`make test-python-ci`, which uses a debug extension build).
 - Node runtime tests: `node_tests` builds the N-API module in debug mode, type-checks the generated declarations, and runs the JavaScript tests.
-- Windows native-binding gate: `windows_node_tests` verifies platform file identifiers and builds the N-API module in debug mode on branches. Exact `vMAJOR.MINOR.PATCH` tags use the release build.
+- Windows native-binding gate: `windows_node_tests` verifies platform file identifiers and builds the N-API module in debug mode on branches. The Rust test and N-API build share the detected host target so debug artifacts are reused. Exact `vMAJOR.MINOR.PATCH` tags use the release build.
 - Test jobs are gated on all three quality jobs passing.
 - CI caches package-manager downloads per executor. Only `rust_quality` caches `target/`; jobs do not transfer build artifacts through a workspace.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,10 @@ Tests are in `tests/` (pytest for Python bindings). Benchmarks live in `benches/
 - `make develop`: build/install the Python extension locally via `maturin --release`.
 - `make develop-debug`: build/install the Python extension in debug mode (faster, CI-friendly).
 - `make develop-release`: build/install the Python extension in release mode.
-- `make quality`: run Rust checks plus Python quality checks (`ruff format --check`, `ruff check`, `basedpyright`).
+- `make quality`: run Rust checks plus Python and Node quality checks.
 - `make quality-python`: run Python quality checks only.
 - `make style`: apply auto-fixes (`cargo fix`, `clippy --fix`, `cargo fmt`, `ruff check --fix`, `ruff format`).
-- `make test`: run Rust tests and Python tests.
+- `make test`: run Rust, Python, and Node tests.
 - `make test-python`: run only the Python test suite under `tests/`.
 - `make test-python-ci`: run Python tests against a debug extension build (CI target).
 
@@ -41,12 +41,15 @@ Python style is formatter-driven:
 - Test files use `test_*.py`; test functions use `test_*`.
 
 ## CI Quality Pipeline
-- Rust quality gate: `rust_quality` job (`cargo fmt --check`, `cargo clippy --all-features -- -D warnings`).
+- Rust quality gate: `rust_quality` job (`cargo fmt -- --check`, `cargo clippy --workspace --all-features -- -D warnings`).
 - Python quality gate: `python_quality` job (Python 3.13; runs `make init-no-project` then `make quality-python`).
-- Rust runtime tests: `rust_tests` job (`cargo test --all-features`).
+- Node quality gate: `node_quality` installs Node dependencies and runs TypeScript checks without compiling the native module.
+- Rust runtime tests: `rust_tests` job (`cargo test --workspace --all-features`).
 - Python runtime tests: `python_tests` job (`make test-python-ci`, which uses a debug extension build).
-- Windows native-binding gate: `windows_node_tests` verifies platform file identifiers and builds the N-API module on Windows Server.
+- Node runtime tests: `node_tests` builds the N-API module in debug mode, type-checks the generated declarations, and runs the JavaScript tests.
+- Windows native-binding gate: `windows_node_tests` verifies platform file identifiers and builds the N-API module in debug mode on branches. Exact `vMAJOR.MINOR.PATCH` tags use the release build.
 - Test jobs are gated on all three quality jobs passing.
+- CI caches package-manager downloads per executor. Only `rust_quality` caches `target/`; jobs do not transfer build artifacts through a workspace.
 
 ## Testing Guidelines
 Add or update tests when behavior changes in preprocessing, manifest generation, TIFF I/O, or Python bindings.

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "napi build --release --platform --dts index.d.ts --js index.js",
     "build:debug": "napi build --platform --dts index.d.ts --js index.js",
-    "typecheck": "npm run build && tsc --noEmit",
-    "test": "npm run build:debug && node --test test/*.test.mjs"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build:debug && npm run typecheck && node --test test/*.test.mjs"
   },
   "napi": {
     "binaryName": "dicom_preprocessing_node",

--- a/tests/test_circleci.py
+++ b/tests/test_circleci.py
@@ -1,40 +1,135 @@
+import json
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).parents[1]
+CIRCLECI_CONFIG_PATH = REPOSITORY_ROOT / ".circleci" / "config.yml"
+NODE_PACKAGE_PATH = REPOSITORY_ROOT / "bindings" / "node" / "package.json"
 QUALITY_JOBS = {"rust_quality", "python_quality", "node_quality"}
+WORKFLOW_JOBS = (
+    "rust_quality",
+    "python_quality",
+    "rust_tests",
+    "python_tests",
+    "node_quality",
+    "node_tests",
+    "windows_node_tests",
+)
+VERSION_TAG_FILTER = "/^v[0-9]+\\.[0-9]+\\.[0-9]+$/"
 
 
-def workflow_job_requirements(config: str, job_name: str) -> set[str]:
+def job_definition(config: str, job_name: str) -> str:
     lines = config.splitlines()
-    job_markers = {f"- {job_name}", f"- {job_name}:"}
+    job_marker = f"    {job_name}:"
 
     for job_index, line in enumerate(lines):
-        if line.strip() not in job_markers:
+        if line != job_marker:
+            continue
+
+        job_lines = [line]
+        for job_line in lines[job_index + 1 :]:
+            job_indent = len(job_line) - len(job_line.lstrip())
+            if job_line.strip() and job_indent <= 4:
+                break
+            job_lines.append(job_line)
+        return "\n".join(job_lines)
+
+    raise AssertionError(f"Job definition not found: {job_name}")
+
+
+def workflow_job_definition(config: str, job_name: str) -> str:
+    lines = config.splitlines()
+    job_markers = {f"            - {job_name}", f"            - {job_name}:"}
+
+    for job_index, line in enumerate(lines):
+        if line not in job_markers:
             continue
 
         job_indent = len(line) - len(line.lstrip())
-        for requires_index in range(job_index + 1, len(lines)):
-            requires_line = lines[requires_index]
-            requires_indent = len(requires_line) - len(requires_line.lstrip())
-            if requires_line.strip() and requires_indent <= job_indent:
-                return set()
-            if requires_line.strip() != "requires:":
-                continue
-
-            requirements = set()
-            for dependency_line in lines[requires_index + 1 :]:
-                dependency_indent = len(dependency_line) - len(dependency_line.lstrip())
-                if dependency_line.strip() and dependency_indent <= requires_indent:
-                    break
-                if dependency_line.strip().startswith("- "):
-                    requirements.add(dependency_line.strip().removeprefix("- "))
-            return requirements
-        return set()
+        job_lines = [line]
+        for job_line in lines[job_index + 1 :]:
+            definition_indent = len(job_line) - len(job_line.lstrip())
+            if job_line.strip() and definition_indent <= job_indent:
+                break
+            job_lines.append(job_line)
+        return "\n".join(job_lines)
 
     raise AssertionError(f"Workflow job not found: {job_name}")
 
 
+def workflow_job_requirements(config: str, job_name: str) -> set[str]:
+    lines = workflow_job_definition(config, job_name).splitlines()
+
+    for requires_index, line in enumerate(lines):
+        if line.strip() != "requires:":
+            continue
+
+        requires_indent = len(line) - len(line.lstrip())
+        requirements = set()
+        for dependency_line in lines[requires_index + 1 :]:
+            dependency_indent = len(dependency_line) - len(dependency_line.lstrip())
+            if dependency_line.strip() and dependency_indent <= requires_indent:
+                break
+            if dependency_line.strip().startswith("- "):
+                requirements.add(dependency_line.strip().removeprefix("- "))
+        return requirements
+
+    return set()
+
+
 def test_windows_node_tests_require_quality_jobs() -> None:
-    config = (REPOSITORY_ROOT / ".circleci" / "config.yml").read_text()
+    config = CIRCLECI_CONFIG_PATH.read_text()
 
     assert workflow_job_requirements(config, "windows_node_tests") == QUALITY_JOBS
+
+
+def test_node_validation_uses_debug_builds() -> None:
+    package = json.loads(NODE_PACKAGE_PATH.read_text())
+
+    assert package["scripts"]["typecheck"] == "tsc --noEmit"
+    assert package["scripts"]["test"] == "npm run build:debug && npm run typecheck && node --test test/*.test.mjs"
+
+
+def test_node_quality_does_not_install_rust() -> None:
+    config = CIRCLECI_CONFIG_PATH.read_text()
+
+    assert "Install Rust" not in job_definition(config, "node_quality")
+
+
+def test_windows_build_mode_depends_on_exact_version_tag() -> None:
+    config = CIRCLECI_CONFIG_PATH.read_text()
+    windows_job = job_definition(config, "windows_node_tests")
+
+    assert "cargo test -p dicom-preprocessing --lib file::tests::test_inode_sort" in windows_job
+    assert f"$env:CIRCLE_TAG -match '{VERSION_TAG_FILTER[1:-1]}'" in windows_job
+    assert '"build"' in windows_job
+    assert '"build:debug"' in windows_job
+    assert "name: Install Node dependencies" in windows_job
+    assert "name: Test Windows file identifiers" in windows_job
+    assert "name: Build Node bindings" in windows_job
+
+
+def test_all_workflow_jobs_accept_exact_version_tags() -> None:
+    config = CIRCLECI_CONFIG_PATH.read_text()
+
+    assert VERSION_TAG_FILTER in config
+    for job_name in WORKFLOW_JOBS:
+        filter_alias = "&version_tags" if job_name == "rust_quality" else "*version_tags"
+        assert f"filters: {filter_alias}" in workflow_job_definition(config, job_name)
+
+
+def test_ci_avoids_cross_executor_build_artifacts() -> None:
+    config = CIRCLECI_CONFIG_PATH.read_text()
+
+    assert "persist_to_workspace" not in config
+    assert "attach_workspace" not in config
+    assert "v3-rust-tests" not in config
+    assert "~/.rustup" not in config
+    assert "bindings/node/node_modules" not in config
+
+    assert "v4-rust-deps-" in job_definition(config, "rust_tests")
+    assert "v4-python-rust-deps-" in job_definition(config, "python_tests")
+    assert "v4-node-rust-deps-" in job_definition(config, "node_tests")
+    assert "v4-windows-rust-deps-" in job_definition(config, "windows_node_tests")
+
+    for job_name in ("rust_tests", "python_tests", "node_tests", "windows_node_tests"):
+        assert "./target" not in job_definition(config, job_name)

--- a/tests/test_circleci.py
+++ b/tests/test_circleci.py
@@ -15,6 +15,7 @@ WORKFLOW_JOBS = (
     "windows_node_tests",
 )
 VERSION_TAG_FILTER = "/^v[0-9]+\\.[0-9]+\\.[0-9]+$/"
+WINDOWS_INODE_TEST_COMMAND = "cargo test -p dicom-preprocessing --lib file::tests::test_inode_sort"
 
 
 def job_definition(config: str, job_name: str) -> str:
@@ -99,13 +100,21 @@ def test_windows_build_mode_depends_on_exact_version_tag() -> None:
     config = CIRCLECI_CONFIG_PATH.read_text()
     windows_job = job_definition(config, "windows_node_tests")
 
-    assert "cargo test -p dicom-preprocessing --lib file::tests::test_inode_sort" in windows_job
+    assert WINDOWS_INODE_TEST_COMMAND in windows_job
     assert f"$env:CIRCLE_TAG -match '{VERSION_TAG_FILTER[1:-1]}'" in windows_job
     assert '"build"' in windows_job
     assert '"build:debug"' in windows_job
     assert "name: Install Node dependencies" in windows_job
     assert "name: Test Windows file identifiers" in windows_job
     assert "name: Build Node bindings" in windows_job
+
+
+def test_windows_rust_test_reuses_node_build_target() -> None:
+    config = CIRCLECI_CONFIG_PATH.read_text()
+    windows_job = job_definition(config, "windows_node_tests")
+
+    assert "$rustTargetLine = rustc -vV | Select-String '^host: '" in windows_job
+    assert f"{WINDOWS_INODE_TEST_COMMAND} --target $rustTarget" in windows_job
 
 
 def test_all_workflow_jobs_accept_exact_version_tags() -> None:


### PR DESCRIPTION
## Motivation

Normal CircleCI workflows take about 26–27 minutes because the Windows Node job compiles a debug test target and then performs a separate fat-LTO release build. The workflow also transfers a large workspace and restores Rust build artifacts across incompatible executors, adding latency without improving normal branch coverage.

The first branch validation confirmed that Cargo's host-default test directory and the NAPI CLI's explicit host-target directory caused a second debug dependency compilation on Windows. The workflow now aligns those targets so the split steps reuse artifacts.

## Solution

Use debug native builds for normal Node CI while retaining the Windows release build for exact semantic-version tags. Remove workspace transfers and executor-crossing compiled-artifact caches, keep only executor-scoped package-manager download caches plus the measured Rust quality target cache, and share the Windows host-target debug artifacts between the focused Rust test and NAPI build.

## Changes

- make Node quality run TypeScript checking without installing Rust or compiling the native module
- make Node tests build the debug native module, type-check generated declarations, and run JavaScript tests
- split Windows dependency installation, Rust testing, and native binding compilation into separately timed steps
- narrow the Windows Rust test and select release builds only for exact `vMAJOR.MINOR.PATCH` tags
- detect the Windows Rust host target so the focused test and NAPI debug build reuse compiled dependencies
- apply compatible exact-tag filters to all seven workflow jobs
- remove workspace persistence/attachment and cross-executor Rust target caches
- separate Cargo registry and Git download caches by executor and lockfile
- update `AGENTS.md` to document the debug, cache, workspace, target-reuse, and release-tag behavior

## Test plan

- [x] `uv run pytest tests/test_circleci.py`
- [x] `make quality`
- [x] `make test`
- [x] `npm --prefix bindings/node run build`
- [x] `cargo build --release --workspace --all-features`
- [x] Confirm the corrected branch workflow keeps all seven jobs green and completes within the accepted first-run window
- [ ] Confirm an exact semantic-version tag selects the retained Windows release build

### Observed CircleCI validation

| Branch revision | Workflow | Windows job | Rust test step | Node build step |
|---|---:|---:|---:|---:|
| Initial debug/cache patch | 16:24 | 15:09 | 4:58 | 7:40 |
| Host-target reuse fix | 11:50 | 10:53 | 4:59 | 4:08 |

The corrected run passed all seven jobs and met the accepted 12-minute first-run workflow limit. Its Windows job remains above the estimated 6–8 minute range because the cold focused Rust test and debug NAPI build still take about nine minutes combined.

## Test suite changes

- No tests were removed.
- Retained `test_windows_node_tests_require_quality_jobs` and made its workflow parsing section-aware.
- Added regression coverage for Node debug/type-check sequencing, the Rust-free Node quality job, exact-tag Windows release selection, Windows debug target reuse, compatible workflow tag filters, and removal of workspace and cross-executor build artifacts.
- Expanded coverage intent from quality-job dependencies alone to the CI performance invariants introduced by this change.

Generated with Codex